### PR TITLE
B#34 emptymapping

### DIFF
--- a/sr_utilities/scripts/sr_utilities/hand_finder.py
+++ b/sr_utilities/scripts/sr_utilities/hand_finder.py
@@ -72,7 +72,13 @@ class HandConfig(object):
         """
 
         """
-        self.mapping = mapping
+        # handle possibly empty mapping
+        self.mapping = {}
+        for serial_id in mapping:
+            if mapping[serial_id] == '':
+                self.mapping[serial_id] = str(serial_id)
+            else:
+                self.mapping[serial_id] = mapping[serial_id]
         self.joint_prefix = joint_prefix
 
 

--- a/sr_utilities/scripts/sr_utilities/hand_finder.py
+++ b/sr_utilities/scripts/sr_utilities/hand_finder.py
@@ -119,11 +119,11 @@ class HandJoints(object):
                 self.joints[mapping[hand]] = []
                 for joint in hand_urdf.joints:
                     if joint.type != 'fixed':
-                        joint_prefix = joint.name[:2]
-                        if joint_prefix not in joint_prefix.values():
+                        prefix = joint.name[:3]
+                        if prefix not in joint_prefix.values():
                             rospy.logdebug("joint " + joint.name + "has invalid "
                                            "prefix")
-                        elif joint_prefix == joint_prefix[hand]:
+                        elif prefix == joint_prefix[hand]:
                             joints_tmp.append(joint.name)
                 for joint_unordered in hand_joints:
                     if joint_unordered in joints_tmp:
@@ -155,11 +155,11 @@ class HandFinder(object):
         """
         Parses the parameter server to extract the necessary information.
         """
-        if not rospy.has_param("hand"):
+        if not rospy.has_param("/hand"):
             rospy.logerr("No hand is detected")
             hand_parameters = {'joint_prefix': {}, 'mapping': {}}
         else:
-            hand_parameters = rospy.get_param("hand")
+            hand_parameters = rospy.get_param("/hand")
         self.hand_config = HandConfig(hand_parameters["mapping"],
                                       hand_parameters["joint_prefix"])
         self.hand_joints = HandJoints(self.hand_config.mapping, self.hand_config.joint_prefix).joints

--- a/sr_utilities/scripts/sr_utilities/hand_finder.py
+++ b/sr_utilities/scripts/sr_utilities/hand_finder.py
@@ -102,7 +102,7 @@ class HandJoints(object):
 
         if rospy.has_param('robot_description'):
             robot_description = rospy.get_param('robot_description')
-            
+
             # concatenate all the joints with prefixes
             for hand in mapping:
                 if hand in joint_prefix:
@@ -111,7 +111,7 @@ class HandJoints(object):
                 else:
                     rospy.logwarn("Cannot find serial " + hand +
                                   "in joint_prefix parameters")
-                    
+
             # add the prefixed joints to each hand but remove fixed joints
             hand_urdf = URDF.from_xml_string(robot_description)
             for hand in mapping:
@@ -125,7 +125,7 @@ class HandJoints(object):
                             joints_tmp.append(joint.name)
                         elif prefix not in joint_prefix.values():
                             rospy.logdebug("joint " + joint.name + " has invalid "
-                                          "prefix:" + prefix)
+                                           "prefix:" + prefix)
                         elif prefix == joint_prefix[hand]:
                             joints_tmp.append(joint.name)
                 for joint_unordered in hand_joints:
@@ -146,6 +146,7 @@ class HandJoints(object):
                     rospy.logwarn("Cannot find serial " + hand +
                                   "in joint_prefix parameters")
                 self.joints[mapping[hand]] = hand_joints
+
 
 class HandFinder(object):
     """

--- a/sr_utilities/scripts/sr_utilities/hand_finder.py
+++ b/sr_utilities/scripts/sr_utilities/hand_finder.py
@@ -95,11 +95,14 @@ class HandJoints(object):
         joints = self.get_default_joints()
 
         if rospy.has_param('robot_description'):
+            robot_description = rospy.get_param('robot_description')
+            
+            # concatenate all the joints with prefixes
             for hand in mapping:
                 for joint in joints:
                     hand_joints.append(mapping[hand] + '_' + joint)
-
-            robot_description = rospy.get_param('robot_description')
+                    
+            # add the prefixed joints to each hand but remove fixed joints
             hand_urdf = URDF.from_xml_string(robot_description)
             for hand in mapping:
                 joints_tmp = []
@@ -119,11 +122,14 @@ class HandJoints(object):
         else:
             rospy.logwarn("No robot_description found on parameter server."
                           "Joint names are loaded for 5 finger hand")
+                          
+            # concatenate all the joints with prefixes
             for hand in mapping:
-                hand_mapping = mapping[hand]
-                self.joints[hand_mapping] = []
+                hand_joints = []
                 for joint in joints:
-                    self.joints[hand_mapping].append(hand_mapping + '_' + joint)
+                    hand_joints.append(mapping[hand] + '_' + joint)
+
+                self.joints[mapping[hand]] = hand_joints
 
 
 class HandFinder(object):

--- a/sr_utilities/scripts/sr_utilities/hand_finder.py
+++ b/sr_utilities/scripts/sr_utilities/hand_finder.py
@@ -120,9 +120,12 @@ class HandJoints(object):
                 for joint in hand_urdf.joints:
                     if joint.type != 'fixed':
                         prefix = joint.name[:3]
-                        if prefix not in joint_prefix.values():
-                            rospy.logdebug("joint " + joint.name + "has invalid "
-                                           "prefix")
+                        # is there an empty prefix ?
+                        if "" in joint_prefix.values():
+                            joints_tmp.append(joint.name)
+                        elif prefix not in joint_prefix.values():
+                            rospy.logdebug("joint " + joint.name + " has invalid "
+                                          "prefix:" + prefix)
                         elif prefix == joint_prefix[hand]:
                             joints_tmp.append(joint.name)
                 for joint_unordered in hand_joints:

--- a/sr_utilities/src/sr_hand_finder.cpp
+++ b/sr_utilities/src/sr_hand_finder.cpp
@@ -93,7 +93,7 @@ void SrHandFinder::generate_joints_with_prefix()
         hand_joints.insert(hand.second + default_joint_name);
       }
     }
-std::string robot_description;
+    std::string robot_description;
     ros::param::get("robot_description", robot_description);
     const boost::shared_ptr<ModelInterface> hand_urdf = urdf::parseURDF(robot_description);
     BOOST_FOREACH(hand, hand_config_.joint_prefix_)

--- a/sr_utilities/src/sr_hand_finder.cpp
+++ b/sr_utilities/src/sr_hand_finder.cpp
@@ -66,7 +66,14 @@ SrHandFinder::SrHandFinder()
     std::pair<std::string, std::string> pair;
     BOOST_FOREACH(pair, hand_config_.mapping_)
     {
-      ROS_INFO_STREAM("detected hands are \n" << "hand serial:" << pair.first << " hand_id:" << pair.second);
+      // hand empty mapping
+      if (pair.second.empty())
+      {
+        hand_config_.mapping_[pair.first] = pair.first;
+        ROS_INFO_STREAM("detected hands are \n" << "hand serial:" << pair.first << " hand_id:" << pair.second << " , replaced internally by: " << pair.first);
+      }
+      else
+        ROS_INFO_STREAM("detected hands are \n" << "hand serial:" << pair.first << " hand_id:" << pair.second);
     }
 
     generate_joints_with_prefix();

--- a/sr_utilities/src/sr_hand_finder.cpp
+++ b/sr_utilities/src/sr_hand_finder.cpp
@@ -70,7 +70,8 @@ SrHandFinder::SrHandFinder()
       if (pair.second.empty())
       {
         hand_config_.mapping_[pair.first] = pair.first;
-        ROS_INFO_STREAM("detected hands are \n" << "hand serial:" << pair.first << " hand_id:" << pair.second << " , replaced internally by: " << pair.first);
+        ROS_INFO_STREAM("detected hands are \n" << "hand serial:" << pair.first << " hand_id:"
+                        << pair.second << " , replaced internally by: " << pair.first);
       }
       else
         ROS_INFO_STREAM("detected hands are \n" << "hand serial:" << pair.first << " hand_id:" << pair.second);

--- a/sr_utilities/src/sr_hand_finder.cpp
+++ b/sr_utilities/src/sr_hand_finder.cpp
@@ -33,6 +33,7 @@
 #include <set>
 #include <vector>
 #include <string>
+#include <iostream>
 
 using boost::assign::list_of;
 using urdf::ModelInterface;
@@ -58,6 +59,7 @@ SrHandFinder::SrHandFinder()
 {
   if (ros::param::has("hand"))
   {
+    std::map<std::string, std::string> mapping_map;
     ros::param::get("hand/mapping", hand_config_.mapping_);
     ros::param::get("hand/joint_prefix", hand_config_.joint_prefix_);
 
@@ -91,8 +93,7 @@ void SrHandFinder::generate_joints_with_prefix()
         hand_joints.insert(hand.second + default_joint_name);
       }
     }
-
-    std::string robot_description;
+std::string robot_description;
     ros::param::get("robot_description", robot_description);
     const boost::shared_ptr<ModelInterface> hand_urdf = urdf::parseURDF(robot_description);
     BOOST_FOREACH(hand, hand_config_.joint_prefix_)

--- a/sr_utilities/test/test_hand_finder.cpp
+++ b/sr_utilities/test/test_hand_finder.cpp
@@ -95,7 +95,7 @@ TEST(SrHandFinder, one_hand_no_robot_description_finder_test)
   {
     ROS_DEBUG_STREAM(rh_joints[i]);
     ASSERT_STREQ(rh_joints[i].c_str(), ("rh_" + joint_names[i]).c_str());
-  }
+    }
 
   // calibration
   ASSERT_GT(hand_finder.get_calibration_path().size(), 0);
@@ -177,7 +177,7 @@ TEST(SrHandFinder, one_hand_no_mapping_no_robot_description_finder_test)
   {
     ROS_DEBUG_STREAM(rh_joints[i]);
     ASSERT_STREQ(rh_joints[i].c_str(), ("rh_" + joint_names[i]).c_str());
-  }
+    }
 
   // calibration
   ASSERT_GT(hand_finder.get_calibration_path().size(), 0);
@@ -499,7 +499,7 @@ TEST(SrHandFinder, two_hand_robot_description_exists_finder_test)
   const string dir[] =  {"right", "left"};
   
   shadow_robot::SrHandFinder hand_finder;
-
+  
   ASSERT_EQ(hand_finder.get_hand_parameters().mapping_.size(), 2);
   ASSERT_EQ(hand_finder.get_hand_parameters().joint_prefix_.size(), 2);
   ASSERT_EQ(hand_finder.get_joints().size(), 2);

--- a/sr_utilities/test/test_hand_finder.cpp
+++ b/sr_utilities/test/test_hand_finder.cpp
@@ -100,7 +100,7 @@ TEST(SrHandFinder, one_hand_no_robot_description_finder_test)
   // calibration
   ASSERT_GT(hand_finder.get_calibration_path().size(), 0);
   const string calibration_path = hand_finder.get_calibration_path().at("right");
-  ROS_INFO_STREAM(calibration_path.c_str());
+  ROS_DEBUG_STREAM(calibration_path.c_str());
   ASSERT_STREQ(calibration_path.c_str(), (ethercat_path + "/calibrations/right/" + "calibration.yaml").c_str());
 
   // tuning
@@ -182,7 +182,7 @@ TEST(SrHandFinder, one_hand_no_mapping_no_robot_description_finder_test)
   // calibration
   ASSERT_GT(hand_finder.get_calibration_path().size(), 0);
   const string calibration_path = hand_finder.get_calibration_path().at("1");
-  ROS_INFO_STREAM(calibration_path.c_str());
+  ROS_DEBUG_STREAM(calibration_path.c_str());
   ASSERT_STREQ(calibration_path.c_str(), (ethercat_path + "/calibrations/1/" + "calibration.yaml").c_str());
 
   // tuning
@@ -264,7 +264,7 @@ TEST(SrHandFinder, one_hand_no_prefix_no_robot_description_finder_test)
   // calibration
   ASSERT_GT(hand_finder.get_calibration_path().size(), 0);
   const string calibration_path = hand_finder.get_calibration_path().at("rh");
-  ROS_INFO_STREAM(calibration_path.c_str());
+  ROS_DEBUG_STREAM(calibration_path.c_str());
   ASSERT_STREQ(calibration_path.c_str(), (ethercat_path + "/calibrations/rh/" + "calibration.yaml").c_str());
 
   // tuning
@@ -346,7 +346,7 @@ TEST(SrHandFinder, one_hand_no_mapping_no_prefix_no_robot_description_finder_tes
   // calibration
   ASSERT_GT(hand_finder.get_calibration_path().size(), 0);
   const string calibration_path = hand_finder.get_calibration_path().at("1");
-  ROS_INFO_STREAM(calibration_path.c_str());
+  ROS_DEBUG_STREAM(calibration_path.c_str());
   ASSERT_STREQ(calibration_path.c_str(), (ethercat_path + "/calibrations/1/" + "calibration.yaml").c_str());
 
   // tuning
@@ -400,7 +400,7 @@ TEST(SrHandFinder, one_hand_robot_description_exists_finger_test)
   }
 
   string right_hand_description;
-  ros::param::get("right_hands_description", right_hand_description);
+  ros::param::get("right_hand_description", right_hand_description);
   ros::param::set("robot_description", right_hand_description);
 
   ros::param::set("hand/mapping/1", "right");
@@ -428,7 +428,7 @@ TEST(SrHandFinder, one_hand_robot_description_exists_finger_test)
   // calibration
   ASSERT_GT(hand_finder.get_calibration_path().size(), 0);
   const string calibration_path = hand_finder.get_calibration_path().at("right");
-  ROS_INFO_STREAM(calibration_path.c_str());
+  ROS_DEBUG_STREAM(calibration_path.c_str());
   ASSERT_STREQ(calibration_path.c_str(), (ethercat_path + "/calibrations/right/" + "calibration.yaml").c_str());
 
   // tuning
@@ -495,8 +495,7 @@ TEST(SrHandFinder, two_hand_robot_description_exists_finder_test)
                                 "THJ1", "THJ2", "THJ3", "THJ4", "THJ5", "WRJ1", "WRJ2"};
 
   unsigned idx = 0;
-  const string prefix[] =  {"rh_", "lh_"};
-  const string dir[] =  {"right", "left"};
+  const string dir[] =  {"left", "right"};
   
   shadow_robot::SrHandFinder hand_finder;
   
@@ -511,12 +510,12 @@ TEST(SrHandFinder, two_hand_robot_description_exists_finder_test)
   ASSERT_MAP_HAS_VALUE(hand_finder.get_hand_parameters().joint_prefix_, "rh_");
   ASSERT_MAP_HAS_VALUE(hand_finder.get_hand_parameters().joint_prefix_, "lh_");
 
-  ASSERT_GT(hand_finder.get_joints().count("rh"), 0);
+  ASSERT_GT(hand_finder.get_joints().count("right"), 0);
   const vector<string> rh_joints = hand_finder.get_joints().at("right");
   ASSERT_EQ(std::find(rh_joints.begin(), rh_joints.end(), "rh_FFJ3"), rh_joints.end());
   ASSERT_NE(std::find(rh_joints.begin(), rh_joints.end(), "rh_RFJ4"), rh_joints.end());
 
-  ASSERT_GT(hand_finder.get_joints().count("lh"), 0);
+  ASSERT_GT(hand_finder.get_joints().count("left"), 0);
   const vector<string> lh_joints = hand_finder.get_joints().at("left");
   ASSERT_EQ(std::find(lh_joints.begin(), lh_joints.end(), "lh_FFJ1"), lh_joints.end());
   ASSERT_NE(std::find(lh_joints.begin(), lh_joints.end(), "lh_LFJ4"), lh_joints.end());
@@ -526,7 +525,7 @@ TEST(SrHandFinder, two_hand_robot_description_exists_finder_test)
   idx = 0;
   for (map<string, string>::const_iterator iter = calibration_path.begin(); iter != calibration_path.end(); ++iter)
   {
-    ROS_INFO_STREAM(iter->second);
+    ROS_DEBUG_STREAM(iter->first << ":" << iter->second);
     ASSERT_STREQ(iter->second.c_str(), (ethercat_path + "/calibrations/" + dir[idx] + "/" + "calibration.yaml").c_str());
     idx++;
   }

--- a/sr_utilities/test/test_hand_finder.cpp
+++ b/sr_utilities/test/test_hand_finder.cpp
@@ -165,7 +165,7 @@ TEST(SrHandFinder, one_hand_no_mapping_no_robot_description_finder_test)
   // hand parameters
   ASSERT_GT(hand_finder.get_hand_parameters().mapping_.size(), 0);
   ASSERT_GT(hand_finder.get_hand_parameters().joint_prefix_.size(), 0);
-  ASSERT_EQ(hand_finder.get_hand_parameters().mapping_["1"], "");
+  ASSERT_EQ(hand_finder.get_hand_parameters().mapping_["1"], "1");
   ASSERT_EQ(hand_finder.get_hand_parameters().joint_prefix_["1"], "rh_");
   
   // hand joints
@@ -329,7 +329,7 @@ TEST(SrHandFinder, one_hand_no_mapping_no_prefix_no_robot_description_finder_tes
   // hand parameters
   ASSERT_GT(hand_finder.get_hand_parameters().mapping_.size(), 0);
   ASSERT_GT(hand_finder.get_hand_parameters().joint_prefix_.size(), 0);
-  ASSERT_EQ(hand_finder.get_hand_parameters().mapping_["1"], "");
+  ASSERT_EQ(hand_finder.get_hand_parameters().mapping_["1"], "1");
   ASSERT_EQ(hand_finder.get_hand_parameters().joint_prefix_["1"], "");
   
   // hand joints

--- a/sr_utilities/test/test_hand_finder.cpp
+++ b/sr_utilities/test/test_hand_finder.cpp
@@ -9,6 +9,7 @@
 #include "ros/ros.h"
 #include <ros/package.h>
 #include <utility>
+#include <iostream>
 #include <map>
 #include <vector>
 #include <string>
@@ -70,107 +71,205 @@ TEST(SrHandFinder, one_hand_no_robot_description_finder_test)
     ros::param::del("robot_description");
   }
 
-  ros::param::set("hand/mapping/1", "rh");
+  ros::param::set("hand/mapping/1", "right");
   ros::param::set("hand/joint_prefix/1", "rh_");
 
-  shadow_robot::SrHandFinder hand_finder;
-
-  ASSERT_GT(hand_finder.get_hand_parameters().mapping_.size(), 0);
-  ASSERT_GT(hand_finder.get_hand_parameters().joint_prefix_.size(), 0);
-  ASSERT_GT(hand_finder.get_joints().size(), 0);
-  ASSERT_GT(hand_finder.get_calibration_path().size(), 0);
-
-  ASSERT_EQ(hand_finder.get_hand_parameters().mapping_["1"], "rh");
-  ASSERT_EQ(hand_finder.get_hand_parameters().joint_prefix_["1"], "rh_");
-
-  ASSERT_EQ(hand_finder.get_joints().size(), 1);
-  ASSERT_GT(hand_finder.get_joints().count("rh"), 0);
-
-  const vector<string> rh_joints = hand_finder.get_joints().at("rh");
-  ASSERT_NE(std::find(rh_joints.begin(), rh_joints.end(), "rh_FFJ3"), rh_joints.end());
-}
-
-TEST(SrHandFinder, two_hand_robot_description_exists_finder_test)
-{
-  if (ros::param::has("hand"))
-  {
-    ros::param::del("hand");
-  }
-
-  if (ros::param::has("robot_description"))
-  {
-    ros::param::del("robot_description");
-  }
-
-  ros::param::set("hand/mapping/1", "rh");
-  ros::param::set("hand/joint_prefix/1", "rh_");
-  ros::param::set("hand/mapping/2", "lh");
-  ros::param::set("hand/joint_prefix/2", "lh_");
-
-  string two_hands_description;
-  ros::param::get("two_hands_description", two_hands_description);
-  ros::param::set("robot_description", two_hands_description);
-
-  shadow_robot::SrHandFinder hand_finder;
-
-  ASSERT_EQ(hand_finder.get_hand_parameters().mapping_.size(), 2);
-  ASSERT_EQ(hand_finder.get_hand_parameters().joint_prefix_.size(), 2);
-  ASSERT_EQ(hand_finder.get_joints().size(), 2);
-  ASSERT_GT(hand_finder.get_calibration_path().size(), 0);
-
-  ASSERT_MAP_HAS_VALUE(hand_finder.get_hand_parameters().mapping_, "rh");
-  ASSERT_MAP_HAS_VALUE(hand_finder.get_hand_parameters().mapping_, "lh");
-
-  ASSERT_MAP_HAS_VALUE(hand_finder.get_hand_parameters().joint_prefix_, "rh_");
-  ASSERT_MAP_HAS_VALUE(hand_finder.get_hand_parameters().joint_prefix_, "lh_");
-
-  ASSERT_GT(hand_finder.get_joints().count("rh"), 0);
-  const vector<string> rh_joints = hand_finder.get_joints().at("rh");
-  ASSERT_EQ(std::find(rh_joints.begin(), rh_joints.end(), "rh_FFJ3"), rh_joints.end());
-  ASSERT_NE(std::find(rh_joints.begin(), rh_joints.end(), "rh_RFJ4"), rh_joints.end());
-
-  ASSERT_GT(hand_finder.get_joints().count("lh"), 0);
-  const vector<string> lh_joints = hand_finder.get_joints().at("lh");
-  ASSERT_EQ(std::find(lh_joints.begin(), lh_joints.end(), "lh_FFJ1"), lh_joints.end());
-  ASSERT_NE(std::find(lh_joints.begin(), lh_joints.end(), "lh_LFJ4"), lh_joints.end());
-}
-
-TEST(SrHandFinder, hand_present_test)
-{
-  if (ros::param::has("hand"))
-  {
-    ros::param::del("hand");
-  }
-
-  if (ros::param::has("robot_description"))
-  {
-    ros::param::del("robot_description");
-  }
-
-  ros::NodeHandle nh;
-  nh.setParam("hand/mapping/1", "rh");
-  nh.setParam("hand/joint_prefix/1", "rh_");
+  string ethercat_path = ros::package::getPath("sr_ethercat_hand_config");
   const string joint_names[] = {"FFJ1", "FFJ2", "FFJ3", "FFJ4", "MFJ1", "MFJ2", "MFJ3", "MFJ4",
                                 "RFJ1", "RFJ2", "RFJ3", "RFJ4", "LFJ1", "LFJ2", "LFJ3", "LFJ4", "LFJ5",
                                 "THJ1", "THJ2", "THJ3", "THJ4", "THJ5", "WRJ1", "WRJ2"};
+
   shadow_robot::SrHandFinder hand_finder;
-  map<string, vector<string> > hand_joints(hand_finder.get_joints());
-  for (map<string, vector<string> >::const_iterator iter = hand_joints.begin(); iter != hand_joints.end(); ++iter)
+  // hand parameters
+  ASSERT_GT(hand_finder.get_hand_parameters().mapping_.size(), 0);
+  ASSERT_GT(hand_finder.get_hand_parameters().joint_prefix_.size(), 0);
+  ASSERT_EQ(hand_finder.get_hand_parameters().mapping_["1"], "right");
+  ASSERT_EQ(hand_finder.get_hand_parameters().joint_prefix_["1"], "rh_");
+  
+  // hand joints
+  ASSERT_EQ(hand_finder.get_joints().size(), 1); 
+  ASSERT_GT(hand_finder.get_joints().count("right"), 0);
+  const vector<string> rh_joints = hand_finder.get_joints().at("right");
+  ASSERT_EQ(rh_joints.size(), 24);
+  for (size_t i = 0; i < rh_joints.size(); ++i)
   {
+    ROS_DEBUG_STREAM(rh_joints[i]);
+    ASSERT_STREQ(rh_joints[i].c_str(), ("rh_" + joint_names[i]).c_str());
+  }
+
+  // calibration
+  ASSERT_GT(hand_finder.get_calibration_path().size(), 0);
+  const string calibration_path = hand_finder.get_calibration_path().at("right");
+  ROS_INFO_STREAM(calibration_path.c_str());
+  ASSERT_STREQ(calibration_path.c_str(), (ethercat_path + "/calibrations/right/" + "calibration.yaml").c_str());
+
+  // tuning
+  shadow_robot::HandControllerTuning controller_tuning(hand_finder.get_hand_controller_tuning());
+  
+  for (map<string, string>::const_iterator iter = controller_tuning.friction_compensation_.begin();
+       iter != controller_tuning.friction_compensation_.end(); ++iter)
+  {
+    ASSERT_STREQ(iter->second.c_str(), (ethercat_path + "/controls/friction_compensation.yaml").c_str());
+    ROS_DEBUG_STREAM(iter->second);
+  }
+  for (map<string, string>::const_iterator iter = controller_tuning.motor_control_.begin();
+       iter != controller_tuning.motor_control_.end(); ++iter)
+  {
+    ASSERT_STREQ(iter->second.c_str(),
+                 (ethercat_path + "/controls/motors/right/motor_board_effort_controllers.yaml").c_str());
+    ROS_DEBUG_STREAM(iter->second);
+  }
+  for (map<string, vector<string> >::const_iterator iter = controller_tuning.host_control_.begin();
+       iter != controller_tuning.host_control_.end(); ++iter)
+  {
+    string host_array[] = {"sr_edc_calibration_controllers.yaml",
+                           "sr_edc_joint_velocity_controllers_PWM.yaml",
+                           "sr_edc_effort_controllers_PWM.yaml",
+                           "sr_edc_joint_velocity_controllers.yaml",
+                           "sr_edc_effort_controllers.yaml",
+                           "sr_edc_mixed_position_velocity_joint_controllers_PWM.yaml",
+                           "sr_edc_joint_position_controllers_PWM.yaml",
+                           "sr_edc_mixed_position_velocity_joint_controllers.yaml",
+                           "sr_edc_joint_position_controllers.yaml"};
+    vector<string> host_controller_files(host_array, host_array + 9);
+    ASSERT_EQ(host_controller_files.size(), iter->second.size());
     for (size_t i = 0; i != iter->second.size(); ++i)
     {
+      ASSERT_STREQ(iter->second[i].c_str(), (ethercat_path + "/controls/host/right/" + host_controller_files[i]).c_str());
       ROS_DEBUG_STREAM(iter->second[i]);
-      ASSERT_STREQ(iter->second[i].c_str(), ("rh_" + joint_names[i]).c_str());
     }
   }
-  string ethercat_path = ros::package::getPath("sr_ethercat_hand_config");
-  map<string, string> calibration_path(hand_finder.get_calibration_path());
-  for (map<string, string>::const_iterator iter = calibration_path.begin(); iter != calibration_path.end(); ++iter)
+}
+
+TEST(SrHandFinder, one_hand_no_mapping_no_robot_description_finder_test)
+{
+  if (ros::param::has("hand"))
   {
-    ROS_INFO_STREAM(iter->second);
-    ASSERT_STREQ(iter->second.c_str(), (ethercat_path + "/calibrations/rh/" + "calibration.yaml").c_str());
+    ros::param::del("hand");
   }
+
+  if (ros::param::has("robot_description"))
+  {
+    ros::param::del("robot_description");
+  }
+
+  ros::param::set("hand/mapping/1", "");
+  ros::param::set("hand/joint_prefix/1", "rh_");
+
+  string ethercat_path = ros::package::getPath("sr_ethercat_hand_config");
+  const string joint_names[] = {"FFJ1", "FFJ2", "FFJ3", "FFJ4", "MFJ1", "MFJ2", "MFJ3", "MFJ4",
+                                "RFJ1", "RFJ2", "RFJ3", "RFJ4", "LFJ1", "LFJ2", "LFJ3", "LFJ4", "LFJ5",
+                                "THJ1", "THJ2", "THJ3", "THJ4", "THJ5", "WRJ1", "WRJ2"};
+
+  shadow_robot::SrHandFinder hand_finder;
+  // hand parameters
+  ASSERT_GT(hand_finder.get_hand_parameters().mapping_.size(), 0);
+  ASSERT_GT(hand_finder.get_hand_parameters().joint_prefix_.size(), 0);
+  ASSERT_EQ(hand_finder.get_hand_parameters().mapping_["1"], "");
+  ASSERT_EQ(hand_finder.get_hand_parameters().joint_prefix_["1"], "rh_");
+  
+  // hand joints
+  ASSERT_EQ(hand_finder.get_joints().size(), 1); 
+  ASSERT_GT(hand_finder.get_joints().count("1"), 0);
+  const vector<string> rh_joints = hand_finder.get_joints().at("1");
+  ASSERT_EQ(rh_joints.size(), 24);
+  for (size_t i = 0; i < rh_joints.size(); ++i)
+  {
+    ROS_DEBUG_STREAM(rh_joints[i]);
+    ASSERT_STREQ(rh_joints[i].c_str(), ("rh_" + joint_names[i]).c_str());
+  }
+
+  // calibration
+  ASSERT_GT(hand_finder.get_calibration_path().size(), 0);
+  const string calibration_path = hand_finder.get_calibration_path().at("1");
+  ROS_INFO_STREAM(calibration_path.c_str());
+  ASSERT_STREQ(calibration_path.c_str(), (ethercat_path + "/calibrations/1/" + "calibration.yaml").c_str());
+
+  // tuning
   shadow_robot::HandControllerTuning controller_tuning(hand_finder.get_hand_controller_tuning());
+  
+  for (map<string, string>::const_iterator iter = controller_tuning.friction_compensation_.begin();
+       iter != controller_tuning.friction_compensation_.end(); ++iter)
+  {
+    ASSERT_STREQ(iter->second.c_str(), (ethercat_path + "/controls/friction_compensation.yaml").c_str());
+    ROS_DEBUG_STREAM(iter->second);
+  }
+  for (map<string, string>::const_iterator iter = controller_tuning.motor_control_.begin();
+       iter != controller_tuning.motor_control_.end(); ++iter)
+  {
+    ASSERT_STREQ(iter->second.c_str(),
+                 (ethercat_path + "/controls/motors/1/motor_board_effort_controllers.yaml").c_str());
+    ROS_DEBUG_STREAM(iter->second);
+  }
+  for (map<string, vector<string> >::const_iterator iter = controller_tuning.host_control_.begin();
+       iter != controller_tuning.host_control_.end(); ++iter)
+  {
+    string host_array[] = {"sr_edc_calibration_controllers.yaml",
+                           "sr_edc_joint_velocity_controllers_PWM.yaml",
+                           "sr_edc_effort_controllers_PWM.yaml",
+                           "sr_edc_joint_velocity_controllers.yaml",
+                           "sr_edc_effort_controllers.yaml",
+                           "sr_edc_mixed_position_velocity_joint_controllers_PWM.yaml",
+                           "sr_edc_joint_position_controllers_PWM.yaml",
+                           "sr_edc_mixed_position_velocity_joint_controllers.yaml",
+                           "sr_edc_joint_position_controllers.yaml"};
+    vector<string> host_controller_files(host_array, host_array + 9);
+    ASSERT_EQ(host_controller_files.size(), iter->second.size());
+    for (size_t i = 0; i != iter->second.size(); ++i)
+    {
+      ASSERT_STREQ(iter->second[i].c_str(), (ethercat_path + "/controls/host/1/" + host_controller_files[i]).c_str());
+      ROS_DEBUG_STREAM(iter->second[i]);
+    }
+  }
+}
+
+TEST(SrHandFinder, one_hand_no_prefix_no_robot_description_finder_test)
+{
+  if (ros::param::has("hand"))
+  {
+    ros::param::del("hand");
+  }
+
+  if (ros::param::has("robot_description"))
+  {
+    ros::param::del("robot_description");
+  }
+
+  ros::param::set("hand/mapping/1", "rh");
+  ros::param::set("hand/joint_prefix/1", "");
+
+  string ethercat_path = ros::package::getPath("sr_ethercat_hand_config");
+  const string joint_names[] = {"FFJ1", "FFJ2", "FFJ3", "FFJ4", "MFJ1", "MFJ2", "MFJ3", "MFJ4",
+                                "RFJ1", "RFJ2", "RFJ3", "RFJ4", "LFJ1", "LFJ2", "LFJ3", "LFJ4", "LFJ5",
+                                "THJ1", "THJ2", "THJ3", "THJ4", "THJ5", "WRJ1", "WRJ2"};
+
+  shadow_robot::SrHandFinder hand_finder;
+  // hand parameters
+  ASSERT_GT(hand_finder.get_hand_parameters().mapping_.size(), 0);
+  ASSERT_GT(hand_finder.get_hand_parameters().joint_prefix_.size(), 0);
+  ASSERT_EQ(hand_finder.get_hand_parameters().mapping_["1"], "rh");
+  ASSERT_EQ(hand_finder.get_hand_parameters().joint_prefix_["1"], "");
+  
+  // hand joints
+  ASSERT_EQ(hand_finder.get_joints().size(), 1); 
+  ASSERT_GT(hand_finder.get_joints().count("rh"), 0);
+  const vector<string> rh_joints = hand_finder.get_joints().at("rh");
+  ASSERT_EQ(rh_joints.size(), 24); 
+  for (size_t i = 0; i < rh_joints.size(); ++i)
+  {
+    ROS_DEBUG_STREAM(rh_joints[i]);
+    ASSERT_STREQ(rh_joints[i].c_str(), (joint_names[i]).c_str());
+  }
+
+  // calibration
+  ASSERT_GT(hand_finder.get_calibration_path().size(), 0);
+  const string calibration_path = hand_finder.get_calibration_path().at("rh");
+  ROS_INFO_STREAM(calibration_path.c_str());
+  ASSERT_STREQ(calibration_path.c_str(), (ethercat_path + "/calibrations/rh/" + "calibration.yaml").c_str());
+
+  // tuning
+  shadow_robot::HandControllerTuning controller_tuning(hand_finder.get_hand_controller_tuning());
+  
   for (map<string, string>::const_iterator iter = controller_tuning.friction_compensation_.begin();
        iter != controller_tuning.friction_compensation_.end(); ++iter)
   {
@@ -204,7 +303,275 @@ TEST(SrHandFinder, hand_present_test)
       ROS_DEBUG_STREAM(iter->second[i]);
     }
   }
-  ASSERT_TRUE(true);
+}
+
+TEST(SrHandFinder, one_hand_no_mapping_no_prefix_no_robot_description_finder_test)
+{
+  if (ros::param::has("hand"))
+  {
+    ros::param::del("hand");
+  }
+
+  if (ros::param::has("robot_description"))
+  {
+    ros::param::del("robot_description");
+  }
+
+  ros::param::set("hand/mapping/1", "");
+  ros::param::set("hand/joint_prefix/1", "");
+
+  string ethercat_path = ros::package::getPath("sr_ethercat_hand_config");
+  const string joint_names[] = {"FFJ1", "FFJ2", "FFJ3", "FFJ4", "MFJ1", "MFJ2", "MFJ3", "MFJ4",
+                                "RFJ1", "RFJ2", "RFJ3", "RFJ4", "LFJ1", "LFJ2", "LFJ3", "LFJ4", "LFJ5",
+                                "THJ1", "THJ2", "THJ3", "THJ4", "THJ5", "WRJ1", "WRJ2"};
+
+  shadow_robot::SrHandFinder hand_finder;
+  // hand parameters
+  ASSERT_GT(hand_finder.get_hand_parameters().mapping_.size(), 0);
+  ASSERT_GT(hand_finder.get_hand_parameters().joint_prefix_.size(), 0);
+  ASSERT_EQ(hand_finder.get_hand_parameters().mapping_["1"], "");
+  ASSERT_EQ(hand_finder.get_hand_parameters().joint_prefix_["1"], "");
+  
+  // hand joints
+  ASSERT_EQ(hand_finder.get_joints().size(), 1); 
+  ASSERT_GT(hand_finder.get_joints().count("1"), 0);
+  const vector<string> rh_joints = hand_finder.get_joints().at("1");
+  ASSERT_EQ(rh_joints.size(), 24);
+  for (size_t i = 0; i < rh_joints.size(); ++i)
+  {
+    ROS_DEBUG_STREAM(rh_joints[i]);
+    ASSERT_STREQ(rh_joints[i].c_str(), (joint_names[i]).c_str());
+  }
+
+  // calibration
+  ASSERT_GT(hand_finder.get_calibration_path().size(), 0);
+  const string calibration_path = hand_finder.get_calibration_path().at("1");
+  ROS_INFO_STREAM(calibration_path.c_str());
+  ASSERT_STREQ(calibration_path.c_str(), (ethercat_path + "/calibrations/1/" + "calibration.yaml").c_str());
+
+  // tuning
+  shadow_robot::HandControllerTuning controller_tuning(hand_finder.get_hand_controller_tuning());
+  
+  for (map<string, string>::const_iterator iter = controller_tuning.friction_compensation_.begin();
+       iter != controller_tuning.friction_compensation_.end(); ++iter)
+  {
+    ASSERT_STREQ(iter->second.c_str(), (ethercat_path + "/controls/friction_compensation.yaml").c_str());
+    ROS_DEBUG_STREAM(iter->second);
+  }
+  for (map<string, string>::const_iterator iter = controller_tuning.motor_control_.begin();
+       iter != controller_tuning.motor_control_.end(); ++iter)
+  {
+    ASSERT_STREQ(iter->second.c_str(),
+                 (ethercat_path + "/controls/motors/1/motor_board_effort_controllers.yaml").c_str());
+    ROS_DEBUG_STREAM(iter->second);
+  }
+  for (map<string, vector<string> >::const_iterator iter = controller_tuning.host_control_.begin();
+       iter != controller_tuning.host_control_.end(); ++iter)
+  {
+    string host_array[] = {"sr_edc_calibration_controllers.yaml",
+                           "sr_edc_joint_velocity_controllers_PWM.yaml",
+                           "sr_edc_effort_controllers_PWM.yaml",
+                           "sr_edc_joint_velocity_controllers.yaml",
+                           "sr_edc_effort_controllers.yaml",
+                           "sr_edc_mixed_position_velocity_joint_controllers_PWM.yaml",
+                           "sr_edc_joint_position_controllers_PWM.yaml",
+                           "sr_edc_mixed_position_velocity_joint_controllers.yaml",
+                           "sr_edc_joint_position_controllers.yaml"};
+    vector<string> host_controller_files(host_array, host_array + 9);
+    ASSERT_EQ(host_controller_files.size(), iter->second.size());
+    for (size_t i = 0; i != iter->second.size(); ++i)
+    {
+      ASSERT_STREQ(iter->second[i].c_str(), (ethercat_path + "/controls/host/1/" + host_controller_files[i]).c_str());
+      ROS_DEBUG_STREAM(iter->second[i]);
+    }
+  }
+}
+
+TEST(SrHandFinder, one_hand_robot_description_exists_finger_test)
+{
+  if (ros::param::has("hand"))
+  {
+    ros::param::del("hand");
+  }
+
+  if (ros::param::has("robot_description"))
+  {
+    ros::param::del("robot_description");
+  }
+
+  string right_hand_description;
+  ros::param::get("right_hands_description", right_hand_description);
+  ros::param::set("robot_description", right_hand_description);
+
+  ros::param::set("hand/mapping/1", "right");
+  ros::param::set("hand/joint_prefix/1", "rh_");
+  string ethercat_path = ros::package::getPath("sr_ethercat_hand_config");
+  const string joint_names[] = {"FFJ1", "FFJ2", "FFJ3", "FFJ4", "MFJ1", "MFJ2", "MFJ3", "MFJ4",
+                                "RFJ1", "RFJ2", "RFJ3", "RFJ4", "LFJ1", "LFJ2", "LFJ3", "LFJ4", "LFJ5",
+                                "THJ1", "THJ2", "THJ3", "THJ4", "THJ5", "WRJ1", "WRJ2"};
+
+  shadow_robot::SrHandFinder hand_finder;
+  // hand parameters
+  ASSERT_GT(hand_finder.get_hand_parameters().mapping_.size(), 0);
+  ASSERT_GT(hand_finder.get_hand_parameters().joint_prefix_.size(), 0);
+  ASSERT_EQ(hand_finder.get_hand_parameters().mapping_["1"], "right");
+  ASSERT_EQ(hand_finder.get_hand_parameters().joint_prefix_["1"], "rh_");
+  
+  // hand joints
+  ASSERT_EQ(hand_finder.get_joints().size(), 1); 
+  ASSERT_GT(hand_finder.get_joints().count("right"), 0);
+  const vector<string> rh_joints = hand_finder.get_joints().at("right");
+  ASSERT_EQ(rh_joints.size(), 1); // only RFJ4 is there
+  ASSERT_EQ(std::find(rh_joints.begin(), rh_joints.end(), "rh_FFJ3"), rh_joints.end());
+  ASSERT_NE(std::find(rh_joints.begin(), rh_joints.end(), "rh_RFJ4"), rh_joints.end());
+  
+  // calibration
+  ASSERT_GT(hand_finder.get_calibration_path().size(), 0);
+  const string calibration_path = hand_finder.get_calibration_path().at("right");
+  ROS_INFO_STREAM(calibration_path.c_str());
+  ASSERT_STREQ(calibration_path.c_str(), (ethercat_path + "/calibrations/right/" + "calibration.yaml").c_str());
+
+  // tuning
+  shadow_robot::HandControllerTuning controller_tuning(hand_finder.get_hand_controller_tuning());
+  
+  for (map<string, string>::const_iterator iter = controller_tuning.friction_compensation_.begin();
+       iter != controller_tuning.friction_compensation_.end(); ++iter)
+  {
+    ASSERT_STREQ(iter->second.c_str(), (ethercat_path + "/controls/friction_compensation.yaml").c_str());
+    ROS_DEBUG_STREAM(iter->second);
+  }
+  for (map<string, string>::const_iterator iter = controller_tuning.motor_control_.begin();
+       iter != controller_tuning.motor_control_.end(); ++iter)
+  {
+    ASSERT_STREQ(iter->second.c_str(),
+                 (ethercat_path + "/controls/motors/right/motor_board_effort_controllers.yaml").c_str());
+    ROS_DEBUG_STREAM(iter->second);
+  }
+  for (map<string, vector<string> >::const_iterator iter = controller_tuning.host_control_.begin();
+       iter != controller_tuning.host_control_.end(); ++iter)
+  {
+    string host_array[] = {"sr_edc_calibration_controllers.yaml",
+                           "sr_edc_joint_velocity_controllers_PWM.yaml",
+                           "sr_edc_effort_controllers_PWM.yaml",
+                           "sr_edc_joint_velocity_controllers.yaml",
+                           "sr_edc_effort_controllers.yaml",
+                           "sr_edc_mixed_position_velocity_joint_controllers_PWM.yaml",
+                           "sr_edc_joint_position_controllers_PWM.yaml",
+                           "sr_edc_mixed_position_velocity_joint_controllers.yaml",
+                           "sr_edc_joint_position_controllers.yaml"};
+    vector<string> host_controller_files(host_array, host_array + 9);
+    ASSERT_EQ(host_controller_files.size(), iter->second.size());
+    for (size_t i = 0; i != iter->second.size(); ++i)
+    {
+      ASSERT_STREQ(iter->second[i].c_str(), (ethercat_path + "/controls/host/right/" + host_controller_files[i]).c_str());
+      ROS_DEBUG_STREAM(iter->second[i]);
+    }
+  }
+}
+
+TEST(SrHandFinder, two_hand_robot_description_exists_finder_test)
+{
+  if (ros::param::has("hand"))
+  {
+    ros::param::del("hand");
+  }
+
+  if (ros::param::has("robot_description"))
+  {
+    ros::param::del("robot_description");
+  }
+
+  ros::param::set("hand/mapping/1", "right");
+  ros::param::set("hand/joint_prefix/1", "rh_");
+  ros::param::set("hand/mapping/2", "left");
+  ros::param::set("hand/joint_prefix/2", "lh_");
+
+  string two_hands_description;
+  ros::param::get("two_hands_description", two_hands_description);
+  ros::param::set("robot_description", two_hands_description);
+  
+  const string joint_names[] = {"FFJ1", "FFJ2", "FFJ3", "FFJ4", "MFJ1", "MFJ2", "MFJ3", "MFJ4",
+                                "RFJ1", "RFJ2", "RFJ3", "RFJ4", "LFJ1", "LFJ2", "LFJ3", "LFJ4", "LFJ5",
+                                "THJ1", "THJ2", "THJ3", "THJ4", "THJ5", "WRJ1", "WRJ2"};
+
+  unsigned idx = 0;
+  const string prefix[] =  {"rh_", "lh_"};
+  const string dir[] =  {"right", "left"};
+  
+  shadow_robot::SrHandFinder hand_finder;
+
+  ASSERT_EQ(hand_finder.get_hand_parameters().mapping_.size(), 2);
+  ASSERT_EQ(hand_finder.get_hand_parameters().joint_prefix_.size(), 2);
+  ASSERT_EQ(hand_finder.get_joints().size(), 2);
+  ASSERT_GT(hand_finder.get_calibration_path().size(), 0);
+
+  ASSERT_MAP_HAS_VALUE(hand_finder.get_hand_parameters().mapping_, "right");
+  ASSERT_MAP_HAS_VALUE(hand_finder.get_hand_parameters().mapping_, "left");
+
+  ASSERT_MAP_HAS_VALUE(hand_finder.get_hand_parameters().joint_prefix_, "rh_");
+  ASSERT_MAP_HAS_VALUE(hand_finder.get_hand_parameters().joint_prefix_, "lh_");
+
+  ASSERT_GT(hand_finder.get_joints().count("rh"), 0);
+  const vector<string> rh_joints = hand_finder.get_joints().at("right");
+  ASSERT_EQ(std::find(rh_joints.begin(), rh_joints.end(), "rh_FFJ3"), rh_joints.end());
+  ASSERT_NE(std::find(rh_joints.begin(), rh_joints.end(), "rh_RFJ4"), rh_joints.end());
+
+  ASSERT_GT(hand_finder.get_joints().count("lh"), 0);
+  const vector<string> lh_joints = hand_finder.get_joints().at("left");
+  ASSERT_EQ(std::find(lh_joints.begin(), lh_joints.end(), "lh_FFJ1"), lh_joints.end());
+  ASSERT_NE(std::find(lh_joints.begin(), lh_joints.end(), "lh_LFJ4"), lh_joints.end());
+  
+  string ethercat_path = ros::package::getPath("sr_ethercat_hand_config");
+  map<string, string> calibration_path(hand_finder.get_calibration_path());
+  idx = 0;
+  for (map<string, string>::const_iterator iter = calibration_path.begin(); iter != calibration_path.end(); ++iter)
+  {
+    ROS_INFO_STREAM(iter->second);
+    ASSERT_STREQ(iter->second.c_str(), (ethercat_path + "/calibrations/" + dir[idx] + "/" + "calibration.yaml").c_str());
+    idx++;
+  }
+  shadow_robot::HandControllerTuning controller_tuning(hand_finder.get_hand_controller_tuning());
+
+  for (map<string, string>::const_iterator iter = controller_tuning.friction_compensation_.begin();
+       iter != controller_tuning.friction_compensation_.end(); ++iter)
+  {
+    ASSERT_STREQ(iter->second.c_str(), (ethercat_path + "/controls/friction_compensation.yaml").c_str());
+    ROS_DEBUG_STREAM(iter->second);
+  }
+  
+  idx = 0;
+  for (map<string, string>::const_iterator iter = controller_tuning.motor_control_.begin();
+       iter != controller_tuning.motor_control_.end(); ++iter)
+  {
+    
+    ASSERT_STREQ(iter->second.c_str(),
+                 (ethercat_path + "/controls/motors/" + dir[idx] + "/motor_board_effort_controllers.yaml").c_str());
+    ROS_DEBUG_STREAM(iter->second);
+    idx++;
+  }
+  
+  idx = 0;
+  for (map<string, vector<string> >::const_iterator iter = controller_tuning.host_control_.begin();
+       iter != controller_tuning.host_control_.end(); ++iter)
+  {
+    string host_array[] = {"sr_edc_calibration_controllers.yaml",
+                           "sr_edc_joint_velocity_controllers_PWM.yaml",
+                           "sr_edc_effort_controllers_PWM.yaml",
+                           "sr_edc_joint_velocity_controllers.yaml",
+                           "sr_edc_effort_controllers.yaml",
+                           "sr_edc_mixed_position_velocity_joint_controllers_PWM.yaml",
+                           "sr_edc_joint_position_controllers_PWM.yaml",
+                           "sr_edc_mixed_position_velocity_joint_controllers.yaml",
+                           "sr_edc_joint_position_controllers.yaml"};
+    vector<string> host_controller_files(host_array, host_array + 9);
+    ASSERT_EQ(host_controller_files.size(), iter->second.size());
+    for (size_t i = 0; i != iter->second.size(); ++i)
+    {
+      ASSERT_STREQ(iter->second[i].c_str(), (ethercat_path + "/controls/host/" + dir[idx] + "/" + host_controller_files[i]).c_str());
+      ROS_DEBUG_STREAM(iter->second[i]);
+    }
+    idx++;
+  }
 }
 
 

--- a/sr_utilities/test/test_hand_finder.cpp
+++ b/sr_utilities/test/test_hand_finder.cpp
@@ -95,7 +95,7 @@ TEST(SrHandFinder, one_hand_no_robot_description_finder_test)
   {
     ROS_DEBUG_STREAM(rh_joints[i]);
     ASSERT_STREQ(rh_joints[i].c_str(), ("rh_" + joint_names[i]).c_str());
-    }
+  }
 
   // calibration
   ASSERT_GT(hand_finder.get_calibration_path().size(), 0);
@@ -177,7 +177,7 @@ TEST(SrHandFinder, one_hand_no_mapping_no_robot_description_finder_test)
   {
     ROS_DEBUG_STREAM(rh_joints[i]);
     ASSERT_STREQ(rh_joints[i].c_str(), ("rh_" + joint_names[i]).c_str());
-    }
+  }
 
   // calibration
   ASSERT_GT(hand_finder.get_calibration_path().size(), 0);

--- a/sr_utilities/test/test_hand_finder.cpp
+++ b/sr_utilities/test/test_hand_finder.cpp
@@ -85,9 +85,9 @@ TEST(SrHandFinder, one_hand_no_robot_description_finder_test)
   ASSERT_GT(hand_finder.get_hand_parameters().joint_prefix_.size(), 0);
   ASSERT_EQ(hand_finder.get_hand_parameters().mapping_["1"], "right");
   ASSERT_EQ(hand_finder.get_hand_parameters().joint_prefix_["1"], "rh_");
-  
+
   // hand joints
-  ASSERT_EQ(hand_finder.get_joints().size(), 1); 
+  ASSERT_EQ(hand_finder.get_joints().size(), 1);
   ASSERT_GT(hand_finder.get_joints().count("right"), 0);
   const vector<string> rh_joints = hand_finder.get_joints().at("right");
   ASSERT_EQ(rh_joints.size(), 24);
@@ -105,7 +105,7 @@ TEST(SrHandFinder, one_hand_no_robot_description_finder_test)
 
   // tuning
   shadow_robot::HandControllerTuning controller_tuning(hand_finder.get_hand_controller_tuning());
-  
+
   for (map<string, string>::const_iterator iter = controller_tuning.friction_compensation_.begin();
        iter != controller_tuning.friction_compensation_.end(); ++iter)
   {
@@ -135,7 +135,8 @@ TEST(SrHandFinder, one_hand_no_robot_description_finder_test)
     ASSERT_EQ(host_controller_files.size(), iter->second.size());
     for (size_t i = 0; i != iter->second.size(); ++i)
     {
-      ASSERT_STREQ(iter->second[i].c_str(), (ethercat_path + "/controls/host/right/" + host_controller_files[i]).c_str());
+      ASSERT_STREQ(iter->second[i].c_str(), (ethercat_path + "/controls/host/right/" +
+                                             host_controller_files[i]).c_str());
       ROS_DEBUG_STREAM(iter->second[i]);
     }
   }
@@ -167,9 +168,9 @@ TEST(SrHandFinder, one_hand_no_mapping_no_robot_description_finder_test)
   ASSERT_GT(hand_finder.get_hand_parameters().joint_prefix_.size(), 0);
   ASSERT_EQ(hand_finder.get_hand_parameters().mapping_["1"], "1");
   ASSERT_EQ(hand_finder.get_hand_parameters().joint_prefix_["1"], "rh_");
-  
+
   // hand joints
-  ASSERT_EQ(hand_finder.get_joints().size(), 1); 
+  ASSERT_EQ(hand_finder.get_joints().size(), 1);
   ASSERT_GT(hand_finder.get_joints().count("1"), 0);
   const vector<string> rh_joints = hand_finder.get_joints().at("1");
   ASSERT_EQ(rh_joints.size(), 24);
@@ -187,7 +188,7 @@ TEST(SrHandFinder, one_hand_no_mapping_no_robot_description_finder_test)
 
   // tuning
   shadow_robot::HandControllerTuning controller_tuning(hand_finder.get_hand_controller_tuning());
-  
+
   for (map<string, string>::const_iterator iter = controller_tuning.friction_compensation_.begin();
        iter != controller_tuning.friction_compensation_.end(); ++iter)
   {
@@ -249,12 +250,12 @@ TEST(SrHandFinder, one_hand_no_prefix_no_robot_description_finder_test)
   ASSERT_GT(hand_finder.get_hand_parameters().joint_prefix_.size(), 0);
   ASSERT_EQ(hand_finder.get_hand_parameters().mapping_["1"], "rh");
   ASSERT_EQ(hand_finder.get_hand_parameters().joint_prefix_["1"], "");
-  
+
   // hand joints
-  ASSERT_EQ(hand_finder.get_joints().size(), 1); 
+  ASSERT_EQ(hand_finder.get_joints().size(), 1);
   ASSERT_GT(hand_finder.get_joints().count("rh"), 0);
   const vector<string> rh_joints = hand_finder.get_joints().at("rh");
-  ASSERT_EQ(rh_joints.size(), 24); 
+  ASSERT_EQ(rh_joints.size(), 24);
   for (size_t i = 0; i < rh_joints.size(); ++i)
   {
     ROS_DEBUG_STREAM(rh_joints[i]);
@@ -269,7 +270,7 @@ TEST(SrHandFinder, one_hand_no_prefix_no_robot_description_finder_test)
 
   // tuning
   shadow_robot::HandControllerTuning controller_tuning(hand_finder.get_hand_controller_tuning());
-  
+
   for (map<string, string>::const_iterator iter = controller_tuning.friction_compensation_.begin();
        iter != controller_tuning.friction_compensation_.end(); ++iter)
   {
@@ -331,9 +332,9 @@ TEST(SrHandFinder, one_hand_no_mapping_no_prefix_no_robot_description_finder_tes
   ASSERT_GT(hand_finder.get_hand_parameters().joint_prefix_.size(), 0);
   ASSERT_EQ(hand_finder.get_hand_parameters().mapping_["1"], "1");
   ASSERT_EQ(hand_finder.get_hand_parameters().joint_prefix_["1"], "");
-  
+
   // hand joints
-  ASSERT_EQ(hand_finder.get_joints().size(), 1); 
+  ASSERT_EQ(hand_finder.get_joints().size(), 1);
   ASSERT_GT(hand_finder.get_joints().count("1"), 0);
   const vector<string> rh_joints = hand_finder.get_joints().at("1");
   ASSERT_EQ(rh_joints.size(), 24);
@@ -351,7 +352,7 @@ TEST(SrHandFinder, one_hand_no_mapping_no_prefix_no_robot_description_finder_tes
 
   // tuning
   shadow_robot::HandControllerTuning controller_tuning(hand_finder.get_hand_controller_tuning());
-  
+
   for (map<string, string>::const_iterator iter = controller_tuning.friction_compensation_.begin();
        iter != controller_tuning.friction_compensation_.end(); ++iter)
   {
@@ -416,15 +417,15 @@ TEST(SrHandFinder, one_hand_robot_description_exists_finger_test)
   ASSERT_GT(hand_finder.get_hand_parameters().joint_prefix_.size(), 0);
   ASSERT_EQ(hand_finder.get_hand_parameters().mapping_["1"], "right");
   ASSERT_EQ(hand_finder.get_hand_parameters().joint_prefix_["1"], "rh_");
-  
+
   // hand joints
-  ASSERT_EQ(hand_finder.get_joints().size(), 1); 
+  ASSERT_EQ(hand_finder.get_joints().size(), 1);
   ASSERT_GT(hand_finder.get_joints().count("right"), 0);
   const vector<string> rh_joints = hand_finder.get_joints().at("right");
-  ASSERT_EQ(rh_joints.size(), 1); // only RFJ4 is there
+  ASSERT_EQ(rh_joints.size(), 1);  // only RFJ4 is there
   ASSERT_EQ(std::find(rh_joints.begin(), rh_joints.end(), "rh_FFJ3"), rh_joints.end());
   ASSERT_NE(std::find(rh_joints.begin(), rh_joints.end(), "rh_RFJ4"), rh_joints.end());
-  
+
   // calibration
   ASSERT_GT(hand_finder.get_calibration_path().size(), 0);
   const string calibration_path = hand_finder.get_calibration_path().at("right");
@@ -433,7 +434,7 @@ TEST(SrHandFinder, one_hand_robot_description_exists_finger_test)
 
   // tuning
   shadow_robot::HandControllerTuning controller_tuning(hand_finder.get_hand_controller_tuning());
-  
+
   for (map<string, string>::const_iterator iter = controller_tuning.friction_compensation_.begin();
        iter != controller_tuning.friction_compensation_.end(); ++iter)
   {
@@ -463,7 +464,8 @@ TEST(SrHandFinder, one_hand_robot_description_exists_finger_test)
     ASSERT_EQ(host_controller_files.size(), iter->second.size());
     for (size_t i = 0; i != iter->second.size(); ++i)
     {
-      ASSERT_STREQ(iter->second[i].c_str(), (ethercat_path + "/controls/host/right/" + host_controller_files[i]).c_str());
+      ASSERT_STREQ(iter->second[i].c_str(), (ethercat_path + "/controls/host/right/"
+                                             + host_controller_files[i]).c_str());
       ROS_DEBUG_STREAM(iter->second[i]);
     }
   }
@@ -489,16 +491,16 @@ TEST(SrHandFinder, two_hand_robot_description_exists_finder_test)
   string two_hands_description;
   ros::param::get("two_hands_description", two_hands_description);
   ros::param::set("robot_description", two_hands_description);
-  
+
   const string joint_names[] = {"FFJ1", "FFJ2", "FFJ3", "FFJ4", "MFJ1", "MFJ2", "MFJ3", "MFJ4",
                                 "RFJ1", "RFJ2", "RFJ3", "RFJ4", "LFJ1", "LFJ2", "LFJ3", "LFJ4", "LFJ5",
                                 "THJ1", "THJ2", "THJ3", "THJ4", "THJ5", "WRJ1", "WRJ2"};
 
   unsigned idx = 0;
   const string dir[] =  {"left", "right"};
-  
+
   shadow_robot::SrHandFinder hand_finder;
-  
+
   ASSERT_EQ(hand_finder.get_hand_parameters().mapping_.size(), 2);
   ASSERT_EQ(hand_finder.get_hand_parameters().joint_prefix_.size(), 2);
   ASSERT_EQ(hand_finder.get_joints().size(), 2);
@@ -519,14 +521,15 @@ TEST(SrHandFinder, two_hand_robot_description_exists_finder_test)
   const vector<string> lh_joints = hand_finder.get_joints().at("left");
   ASSERT_EQ(std::find(lh_joints.begin(), lh_joints.end(), "lh_FFJ1"), lh_joints.end());
   ASSERT_NE(std::find(lh_joints.begin(), lh_joints.end(), "lh_LFJ4"), lh_joints.end());
-  
+
   string ethercat_path = ros::package::getPath("sr_ethercat_hand_config");
   map<string, string> calibration_path(hand_finder.get_calibration_path());
   idx = 0;
   for (map<string, string>::const_iterator iter = calibration_path.begin(); iter != calibration_path.end(); ++iter)
   {
     ROS_DEBUG_STREAM(iter->first << ":" << iter->second);
-    ASSERT_STREQ(iter->second.c_str(), (ethercat_path + "/calibrations/" + dir[idx] + "/" + "calibration.yaml").c_str());
+    ASSERT_STREQ(iter->second.c_str(), (ethercat_path + "/calibrations/"
+                                        + dir[idx] + "/" + "calibration.yaml").c_str());
     idx++;
   }
   shadow_robot::HandControllerTuning controller_tuning(hand_finder.get_hand_controller_tuning());
@@ -537,18 +540,17 @@ TEST(SrHandFinder, two_hand_robot_description_exists_finder_test)
     ASSERT_STREQ(iter->second.c_str(), (ethercat_path + "/controls/friction_compensation.yaml").c_str());
     ROS_DEBUG_STREAM(iter->second);
   }
-  
+
   idx = 0;
   for (map<string, string>::const_iterator iter = controller_tuning.motor_control_.begin();
        iter != controller_tuning.motor_control_.end(); ++iter)
   {
-    
     ASSERT_STREQ(iter->second.c_str(),
                  (ethercat_path + "/controls/motors/" + dir[idx] + "/motor_board_effort_controllers.yaml").c_str());
     ROS_DEBUG_STREAM(iter->second);
     idx++;
   }
-  
+
   idx = 0;
   for (map<string, vector<string> >::const_iterator iter = controller_tuning.host_control_.begin();
        iter != controller_tuning.host_control_.end(); ++iter)
@@ -566,7 +568,8 @@ TEST(SrHandFinder, two_hand_robot_description_exists_finder_test)
     ASSERT_EQ(host_controller_files.size(), iter->second.size());
     for (size_t i = 0; i != iter->second.size(); ++i)
     {
-      ASSERT_STREQ(iter->second[i].c_str(), (ethercat_path + "/controls/host/" + dir[idx] + "/" + host_controller_files[i]).c_str());
+      ASSERT_STREQ(iter->second[i].c_str(), (ethercat_path + "/controls/host/"
+                                             + dir[idx] + "/" + host_controller_files[i]).c_str());
       ROS_DEBUG_STREAM(iter->second[i]);
     }
     idx++;

--- a/sr_utilities/test/test_hand_finder.py
+++ b/sr_utilities/test/test_hand_finder.py
@@ -6,23 +6,23 @@ import rostest
 import unittest
 from sr_utilities.hand_finder import HandFinder
 joint_names = ["FFJ1", "FFJ2", "FFJ3", "FFJ4", "MFJ1", "MFJ2", "MFJ3", "MFJ4",
-               "RFJ1", "RFJ2", "RFJ3", "RFJ4", "LFJ1", "LFJ2", "LFJ3", "LFJ4", "LFJ5",
-               "THJ1", "THJ2", "THJ3", "THJ4", "THJ5", "WRJ1", "WRJ2"]
+                                "RFJ1", "RFJ2", "RFJ3", "RFJ4", "LFJ1", "LFJ2", "LFJ3", "LFJ4", "LFJ5",
+                                "THJ1", "THJ2", "THJ3", "THJ4", "THJ5", "WRJ1", "WRJ2"]
 controller_params = ["sr_edc_calibration_controllers.yaml",
-                     "sr_edc_joint_velocity_controllers_PWM.yaml",
-                     "sr_edc_effort_controllers_PWM.yaml",
-                     "sr_edc_joint_velocity_controllers.yaml",
-                     "sr_edc_effort_controllers.yaml",
-                     "sr_edc_mixed_position_velocity_joint_controllers_PWM.yaml",
-                     "sr_edc_joint_position_controllers_PWM.yaml",
-                     "sr_edc_mixed_position_velocity_joint_controllers.yaml",
-                     "sr_edc_joint_position_controllers.yaml"]
+                           "sr_edc_joint_velocity_controllers_PWM.yaml",
+                           "sr_edc_effort_controllers_PWM.yaml",
+                           "sr_edc_joint_velocity_controllers.yaml",
+                           "sr_edc_effort_controllers.yaml",
+                           "sr_edc_mixed_position_velocity_joint_controllers_PWM.yaml",
+                           "sr_edc_joint_position_controllers_PWM.yaml",
+                           "sr_edc_mixed_position_velocity_joint_controllers.yaml",
+                           "sr_edc_joint_position_controllers.yaml"]
 
 
 class TestHandFinder(unittest.TestCase):
     rospack = rospkg.RosPack()
     ethercat_path = rospack.get_path('sr_ethercat_hand_config')
-  
+    
     def test_no_hand_no_robot_description_finder(self):
         if rospy.has_param("hand"):
             rospy.delete_param("hand")
@@ -41,7 +41,7 @@ class TestHandFinder(unittest.TestCase):
         self.assertEqual(len(hand_finder.get_hand_control_tuning(). host_control), 0, "correct tuning without a hands")
         self.assertEqual(len(hand_finder.get_hand_control_tuning(). motor_control), 0,
                          "correct tuning without a hands")
-
+                         
     def test_one_hand_no_robot_description_finder(self):
         if rospy.has_param("hand"):
             rospy.delete_param("hand")
@@ -90,10 +90,10 @@ class TestHandFinder(unittest.TestCase):
     def test_one_hand_no_mapping_no_robot_description_finder(self):
         if rospy.has_param("hand"):
             rospy.delete_param("hand")
-
+        
         if rospy.has_param("robot_description"):
             rospy.delete_param("robot_description")
-
+    
         rospy.set_param("hand/joint_prefix/1", "rh_")
         rospy.set_param("hand/mapping/1", "")
 
@@ -132,7 +132,7 @@ class TestHandFinder(unittest.TestCase):
         for controller_path, controller_param in zip(ctrl_tun_host_control_paths, controller_params):
             self.assertEqual(controller_path, self.ethercat_path + "/controls/host/1/" + controller_param,
                              "incorrect controller config file")
-
+            
     def test_one_hand_no_prefix_no_robot_description_finder(self):
         if rospy.has_param("hand"):
             rospy.delete_param("hand")
@@ -177,14 +177,14 @@ class TestHandFinder(unittest.TestCase):
         for controller_path, controller_param in zip(ctrl_tun_host_control_paths, controller_params):
             self.assertEqual(controller_path, self.ethercat_path + "/controls/host/rh/" + controller_param,
                              "incorrect controller config file")
-        
+            
     def test_one_hand_no_prefix_no_mapping_no_robot_description_finder(self):
         if rospy.has_param("hand"):
             rospy.delete_param("hand")
-
+        
         if rospy.has_param("robot_description"):
             rospy.delete_param("robot_description")
-
+            
         rospy.set_param("hand/joint_prefix/1", "")
         rospy.set_param("hand/mapping/1", "")
 

--- a/sr_utilities/test/test_hand_finder.py
+++ b/sr_utilities/test/test_hand_finder.py
@@ -6,23 +6,23 @@ import rostest
 import unittest
 from sr_utilities.hand_finder import HandFinder
 joint_names = ["FFJ1", "FFJ2", "FFJ3", "FFJ4", "MFJ1", "MFJ2", "MFJ3", "MFJ4",
-                                "RFJ1", "RFJ2", "RFJ3", "RFJ4", "LFJ1", "LFJ2", "LFJ3", "LFJ4", "LFJ5",
-                                "THJ1", "THJ2", "THJ3", "THJ4", "THJ5", "WRJ1", "WRJ2"]
+               "RFJ1", "RFJ2", "RFJ3", "RFJ4", "LFJ1", "LFJ2", "LFJ3", "LFJ4", "LFJ5",
+               "THJ1", "THJ2", "THJ3", "THJ4", "THJ5", "WRJ1", "WRJ2"]
 controller_params = ["sr_edc_calibration_controllers.yaml",
-                           "sr_edc_joint_velocity_controllers_PWM.yaml",
-                           "sr_edc_effort_controllers_PWM.yaml",
-                           "sr_edc_joint_velocity_controllers.yaml",
-                           "sr_edc_effort_controllers.yaml",
-                           "sr_edc_mixed_position_velocity_joint_controllers_PWM.yaml",
-                           "sr_edc_joint_position_controllers_PWM.yaml",
-                           "sr_edc_mixed_position_velocity_joint_controllers.yaml",
-                           "sr_edc_joint_position_controllers.yaml"]
+                     "sr_edc_joint_velocity_controllers_PWM.yaml",
+                     "sr_edc_effort_controllers_PWM.yaml",
+                     "sr_edc_joint_velocity_controllers.yaml",
+                     "sr_edc_effort_controllers.yaml",
+                     "sr_edc_mixed_position_velocity_joint_controllers_PWM.yaml",
+                     "sr_edc_joint_position_controllers_PWM.yaml",
+                     "sr_edc_mixed_position_velocity_joint_controllers.yaml",
+                     "sr_edc_joint_position_controllers.yaml"]
 
 
 class TestHandFinder(unittest.TestCase):
     rospack = rospkg.RosPack()
     ethercat_path = rospack.get_path('sr_ethercat_hand_config')
-    
+
     def test_no_hand_no_robot_description_finder(self):
         if rospy.has_param("hand"):
             rospy.delete_param("hand")
@@ -41,7 +41,7 @@ class TestHandFinder(unittest.TestCase):
         self.assertEqual(len(hand_finder.get_hand_control_tuning(). host_control), 0, "correct tuning without a hands")
         self.assertEqual(len(hand_finder.get_hand_control_tuning(). motor_control), 0,
                          "correct tuning without a hands")
-                         
+
     def test_one_hand_no_robot_description_finder(self):
         if rospy.has_param("hand"):
             rospy.delete_param("hand")
@@ -90,10 +90,10 @@ class TestHandFinder(unittest.TestCase):
     def test_one_hand_no_mapping_no_robot_description_finder(self):
         if rospy.has_param("hand"):
             rospy.delete_param("hand")
-        
+
         if rospy.has_param("robot_description"):
             rospy.delete_param("robot_description")
-    
+
         rospy.set_param("hand/joint_prefix/1", "rh_")
         rospy.set_param("hand/mapping/1", "")
 
@@ -109,7 +109,7 @@ class TestHandFinder(unittest.TestCase):
         self.assertEqual(len(hand_finder.get_hand_joints().keys()), 1, "It should be only one mapping")
         print hand_finder.get_hand_joints()
         self.assertIn("1", hand_finder.get_hand_joints(), "Serial should be in the joints result")
-        joints = hand_finder.get_hand_joints()['1'] # use serial
+        joints = hand_finder.get_hand_joints()['1']  # use serial
         self.assertEqual(len(joints), 24, "Joint number should be 24")
         self.assertIn("rh_FFJ3", hand_finder.get_hand_joints()["1"], "FFJ3 joint should be in the joints list")
         # calibration
@@ -132,7 +132,7 @@ class TestHandFinder(unittest.TestCase):
         for controller_path, controller_param in zip(ctrl_tun_host_control_paths, controller_params):
             self.assertEqual(controller_path, self.ethercat_path + "/controls/host/1/" + controller_param,
                              "incorrect controller config file")
-            
+
     def test_one_hand_no_prefix_no_robot_description_finder(self):
         if rospy.has_param("hand"):
             rospy.delete_param("hand")
@@ -177,14 +177,14 @@ class TestHandFinder(unittest.TestCase):
         for controller_path, controller_param in zip(ctrl_tun_host_control_paths, controller_params):
             self.assertEqual(controller_path, self.ethercat_path + "/controls/host/rh/" + controller_param,
                              "incorrect controller config file")
-            
+
     def test_one_hand_no_prefix_no_mapping_no_robot_description_finder(self):
         if rospy.has_param("hand"):
             rospy.delete_param("hand")
-        
+
         if rospy.has_param("robot_description"):
             rospy.delete_param("robot_description")
-            
+
         rospy.set_param("hand/joint_prefix/1", "")
         rospy.set_param("hand/mapping/1", "")
 
@@ -236,17 +236,17 @@ class TestHandFinder(unittest.TestCase):
         rospy.set_param("hand/mapping/2", "left")
 
         hand_finder = HandFinder()
-        
+
         # hand params
         self.assertIsNotNone(hand_finder.get_hand_parameters(), "Parameters extracted.")
         self.assertEqual(len(hand_finder.get_hand_parameters().mapping), 2, "It should be two mappings")
         self.assertIn("right", hand_finder.get_hand_parameters().mapping.values(), "It should be right mapping")
         self.assertIn("left", hand_finder.get_hand_parameters().mapping.values(), "It should be left mapping")
         self.assertEqual(len(hand_finder.get_hand_parameters().joint_prefix), 2, "It should be two joint_prefixes")
-  
+
         self.assertIn("rh_", hand_finder.get_hand_parameters().joint_prefix.values(), "It should be rh_ prefix")
         self.assertIn("lh_", hand_finder.get_hand_parameters().joint_prefix.values(), "It should be rh_ prefix")
-        
+
         # hand joints
         self.assertIsNotNone(hand_finder.get_hand_joints(), "Joints extracted.")
         self.assertEqual(len(hand_finder.get_hand_joints().keys()), 2, "It should be two mappings")
@@ -258,7 +258,7 @@ class TestHandFinder(unittest.TestCase):
         joints = hand_finder.get_hand_joints()['left']
         self.assertEqual(len(joints), 24, "Joint number should be 24")
         self.assertIn("lh_FFJ1", hand_finder.get_hand_joints()["left"], "FFJ1 joint should be in the joints list")
-        
+
         # calibration
         self.assertIsNotNone(hand_finder.get_calibration_path(), "Calibration extracted.")
         calibration_path = hand_finder.get_calibration_path()['right']
@@ -282,7 +282,7 @@ class TestHandFinder(unittest.TestCase):
         for controller_path, controller_param in zip(ctrl_tun_host_control_paths, controller_params):
             self.assertEqual(controller_path, self.ethercat_path + "/controls/host/right/" + controller_param,
                              "incorrect controller config file")
-                             
+
         ctrl_tun_friction_comp_path = hand_finder.get_hand_control_tuning().friction_compensation['left']
         self.assertEqual(ctrl_tun_friction_comp_path, self.ethercat_path + "/controls/friction_compensation.yaml",
                          "incorrect friction compensation file")
@@ -296,7 +296,6 @@ class TestHandFinder(unittest.TestCase):
         for controller_path, controller_param in zip(ctrl_tun_host_control_paths, controller_params):
             self.assertEqual(controller_path, self.ethercat_path + "/controls/host/left/" + controller_param,
                              "incorrect controller config file")
-
 
     def test_no_hand_robot_description_exists_finder(self):
         if rospy.has_param("hand"):
@@ -319,7 +318,7 @@ class TestHandFinder(unittest.TestCase):
         self.assertEqual(len(hand_finder.get_hand_control_tuning(). motor_control), 0,
                          "correct tuning without a hands")
 
-    def test_one_hand_robot_description_exists_finder(self):        
+    def test_one_hand_robot_description_exists_finder(self):
         if rospy.has_param("hand"):
             rospy.delete_param("hand")
 
@@ -343,7 +342,8 @@ class TestHandFinder(unittest.TestCase):
         self.assertIn("right", hand_finder.get_hand_joints(), "Mapping should be in the joints result")
         joints = hand_finder.get_hand_joints()['right']
         self.assertEqual(len(joints), 1, "Joint number should be 1")
-        self.assertNotIn("rh_FFJ3", hand_finder.get_hand_joints()["right"], "FFJ3 joint should not be in the joints list")
+        self.assertNotIn("rh_FFJ3", hand_finder.get_hand_joints()["right"],
+                         "FFJ3 joint should not be in the joints list")
         self.assertIn("rh_RFJ4", hand_finder.get_hand_joints()["right"], "RFJ4 joint should be in the joints list")
         # calibration
         self.assertIsNotNone(hand_finder.get_calibration_path(), "Calibration extracted.")
@@ -412,7 +412,7 @@ class TestHandFinder(unittest.TestCase):
         for controller_path, controller_param in zip(ctrl_tun_host_control_paths, controller_params):
             self.assertEqual(controller_path, self.ethercat_path + "/controls/host/1/" + controller_param,
                              "incorrect controller config file")
-    
+
     def test_one_hand_no_prefix_robot_description_exists_finder(self):
         if rospy.has_param("hand"):
             rospy.delete_param("hand")
@@ -459,7 +459,7 @@ class TestHandFinder(unittest.TestCase):
         for controller_path, controller_param in zip(ctrl_tun_host_control_paths, controller_params):
             self.assertEqual(controller_path, self.ethercat_path + "/controls/host/rh/" + controller_param,
                              "incorrect controller config file")
-        
+
     def test_one_hand_no_prefix_no_ns_robot_description_exists_finder(self):
         if rospy.has_param("hand"):
             rospy.delete_param("hand")
@@ -507,7 +507,7 @@ class TestHandFinder(unittest.TestCase):
             self.assertEqual(controller_path, self.ethercat_path + "/controls/host/1/" + controller_param,
                              "incorrect controller config file")
 
-    def test_two_hand_robot_description_exists_finder(self):    
+    def test_two_hand_robot_description_exists_finder(self):
         if rospy.has_param("hand"):
             rospy.delete_param("hand")
 
@@ -527,24 +527,26 @@ class TestHandFinder(unittest.TestCase):
         self.assertIn("right", hand_finder.get_hand_parameters().mapping.values(), "It should be right mapping")
         self.assertIn("left", hand_finder.get_hand_parameters().mapping.values(), "It should be left mapping")
         self.assertEqual(len(hand_finder.get_hand_parameters().joint_prefix), 2, "It should be two joint_prefixes")
-  
+
         self.assertIn("rh_", hand_finder.get_hand_parameters().joint_prefix.values(), "It should be rh_ prefix")
         self.assertIn("lh_", hand_finder.get_hand_parameters().joint_prefix.values(), "It should be rh_ prefix")
-        
+
         # hand joints
         self.assertIsNotNone(hand_finder.get_hand_joints(), "Joints extracted.")
         self.assertEqual(len(hand_finder.get_hand_joints().keys()), 2, "It should be two mappings")
         self.assertIn("right", hand_finder.get_hand_joints(), "Mapping should be in the joints result")
         joints = hand_finder.get_hand_joints()['right']
         self.assertEqual(len(joints), 1, "Joint number should be 1")
-        self.assertNotIn("rh_FFJ3", hand_finder.get_hand_joints()["right"], "rh_FFJ3 joint should not be in the joints list")
+        self.assertNotIn("rh_FFJ3", hand_finder.get_hand_joints()["right"],
+                         "rh_FFJ3 joint should not be in the joints list")
         self.assertIn("rh_RFJ4", hand_finder.get_hand_joints()["right"], "rh_RFJ4 joint should be in the joints list")
         self.assertIn("left", hand_finder.get_hand_joints(), "Mapping should be in the joints result")
         joints = hand_finder.get_hand_joints()['left']
         self.assertEqual(len(joints), 1, "Joint number should be 1")
-        self.assertNotIn("lh_FFJ3", hand_finder.get_hand_joints()["left"], "lh_FFJ3 joint should not be in the joints list")
+        self.assertNotIn("lh_FFJ3", hand_finder.get_hand_joints()["left"],
+                         "lh_FFJ3 joint should not be in the joints list")
         self.assertIn("lh_LFJ4", hand_finder.get_hand_joints()["left"], "lh_LFJ4 joint should be in the joints list")
-        
+
         # calibration
         self.assertIsNotNone(hand_finder.get_calibration_path(), "Calibration extracted.")
         calibration_path = hand_finder.get_calibration_path()['right']
@@ -568,7 +570,7 @@ class TestHandFinder(unittest.TestCase):
         for controller_path, controller_param in zip(ctrl_tun_host_control_paths, controller_params):
             self.assertEqual(controller_path, self.ethercat_path + "/controls/host/right/" + controller_param,
                              "incorrect controller config file")
-                             
+
         ctrl_tun_friction_comp_path = hand_finder.get_hand_control_tuning().friction_compensation['left']
         self.assertEqual(ctrl_tun_friction_comp_path, self.ethercat_path + "/controls/friction_compensation.yaml",
                          "incorrect friction compensation file")

--- a/sr_utilities/test/test_hand_finder.py
+++ b/sr_utilities/test/test_hand_finder.py
@@ -102,7 +102,7 @@ class TestHandFinder(unittest.TestCase):
         self.assertIsNotNone(hand_finder.get_hand_parameters(), "Parameters extracted.")
         self.assertEqual(len(hand_finder.get_hand_parameters().mapping), 1, "It should be only one mapping")
         self.assertEqual(len(hand_finder.get_hand_parameters().joint_prefix), 1, "It should be only one joint_prefix")
-        self.assertEqual(hand_finder.get_hand_parameters().mapping['1'], "", "It should be only an empty mapping")
+        self.assertEqual(hand_finder.get_hand_parameters().mapping['1'], "1", "It should be the serial id as mapping")
         self.assertEqual(hand_finder.get_hand_parameters().joint_prefix['1'], "rh_", "It should be only rh_ prefix")
         # hand joints
         self.assertIsNotNone(hand_finder.get_hand_joints(), "Joints extracted.")
@@ -193,7 +193,7 @@ class TestHandFinder(unittest.TestCase):
         self.assertIsNotNone(hand_finder.get_hand_parameters(), "Parameters extracted.")
         self.assertEqual(len(hand_finder.get_hand_parameters().mapping), 1, "It should be only one mapping")
         self.assertEqual(len(hand_finder.get_hand_parameters().joint_prefix), 1, "It should be only one joint_prefix")
-        self.assertEqual(hand_finder.get_hand_parameters().mapping['1'], "", "It should be only an empty mapping")
+        self.assertEqual(hand_finder.get_hand_parameters().mapping['1'], "1", "It should be the serial id as mapping")
         self.assertEqual(hand_finder.get_hand_parameters().joint_prefix['1'], "", "It should be only an empty prefix")
         # hand joints
         self.assertIsNotNone(hand_finder.get_hand_joints(), "Joints extracted.")
@@ -382,7 +382,7 @@ class TestHandFinder(unittest.TestCase):
         self.assertIsNotNone(hand_finder.get_hand_parameters(), "Parameters extracted.")
         self.assertEqual(len(hand_finder.get_hand_parameters().mapping), 1, "It should be only one mapping")
         self.assertEqual(len(hand_finder.get_hand_parameters().joint_prefix), 1, "It should be only one joint_prefix")
-        self.assertEqual(hand_finder.get_hand_parameters().mapping['1'], "", "It should be only an empty mapping")
+        self.assertEqual(hand_finder.get_hand_parameters().mapping['1'], "1", "It should be the serial id as mapping")
         self.assertEqual(hand_finder.get_hand_parameters().joint_prefix['1'], "rh_", "It should be only rh_ prefix")
         # hand joints
         self.assertIsNotNone(hand_finder.get_hand_joints(), "Joints extracted.")
@@ -476,7 +476,7 @@ class TestHandFinder(unittest.TestCase):
         self.assertIsNotNone(hand_finder.get_hand_parameters(), "Parameters extracted.")
         self.assertEqual(len(hand_finder.get_hand_parameters().mapping), 1, "It should be only one mapping")
         self.assertEqual(len(hand_finder.get_hand_parameters().joint_prefix), 1, "It should be only one joint_prefix")
-        self.assertEqual(hand_finder.get_hand_parameters().mapping['1'], "", "It should be only an empty mapping")
+        self.assertEqual(hand_finder.get_hand_parameters().mapping['1'], "1", "It should be the serial id as mapping")
         self.assertEqual(hand_finder.get_hand_parameters().joint_prefix['1'], "", "It should be only an empty prefix")
         # hand joints
         self.assertIsNotNone(hand_finder.get_hand_joints(), "Joints extracted.")

--- a/sr_utilities/test/test_hand_finder.py
+++ b/sr_utilities/test/test_hand_finder.py
@@ -422,7 +422,7 @@ class TestHandFinder(unittest.TestCase):
 
         rospy.set_param("hand/joint_prefix/1", "")
         rospy.set_param("hand/mapping/1", "rh")
-        rospy.set_param("robot_description", rospy.get_param("right_hand_description"))
+        rospy.set_param("robot_description", rospy.get_param("right_hand_description_no_prefix"))
 
         hand_finder = HandFinder()
         # hand params
@@ -469,7 +469,7 @@ class TestHandFinder(unittest.TestCase):
 
         rospy.set_param("hand/joint_prefix/1", "")
         rospy.set_param("hand/mapping/1", "")
-        rospy.set_param("robot_description", rospy.get_param("right_hand_description"))
+        rospy.set_param("robot_description", rospy.get_param("right_hand_description_no_prefix"))
 
         hand_finder = HandFinder()
         # hand params

--- a/sr_utilities/test/test_hand_finder.py
+++ b/sr_utilities/test/test_hand_finder.py
@@ -537,13 +537,13 @@ class TestHandFinder(unittest.TestCase):
         self.assertIn("right", hand_finder.get_hand_joints(), "Mapping should be in the joints result")
         joints = hand_finder.get_hand_joints()['right']
         self.assertEqual(len(joints), 1, "Joint number should be 1")
-        self.assertNotIn("rh_FFJ3", hand_finder.get_hand_joints()["right"], "FFJ3 joint should not be in the joints list")
-        self.assertIn("rh_RFJ4", hand_finder.get_hand_joints()["right"], "RFJ4 joint should be in the joints list")
+        self.assertNotIn("rh_FFJ3", hand_finder.get_hand_joints()["right"], "rh_FFJ3 joint should not be in the joints list")
+        self.assertIn("rh_RFJ4", hand_finder.get_hand_joints()["right"], "rh_RFJ4 joint should be in the joints list")
         self.assertIn("left", hand_finder.get_hand_joints(), "Mapping should be in the joints result")
         joints = hand_finder.get_hand_joints()['left']
         self.assertEqual(len(joints), 1, "Joint number should be 1")
-        self.assertNotIn("lh_FFJ3", hand_finder.get_hand_joints()["left"], "FFJ3 joint should not be in the joints list")
-        self.assertIn("lh_RFJ4", hand_finder.get_hand_joints()["left"], "RFJ4 joint should be in the joints list")
+        self.assertNotIn("lh_FFJ3", hand_finder.get_hand_joints()["left"], "lh_FFJ3 joint should not be in the joints list")
+        self.assertIn("lh_LFJ4", hand_finder.get_hand_joints()["left"], "lh_LFJ4 joint should be in the joints list")
         
         # calibration
         self.assertIsNotNone(hand_finder.get_calibration_path(), "Calibration extracted.")

--- a/sr_utilities/test/test_hand_finder.py
+++ b/sr_utilities/test/test_hand_finder.py
@@ -1,12 +1,28 @@
 #!/usr/bin/env python
 
 import rospy
+import rospkg
 import rostest
 import unittest
 from sr_utilities.hand_finder import HandFinder
+joint_names = ["FFJ1", "FFJ2", "FFJ3", "FFJ4", "MFJ1", "MFJ2", "MFJ3", "MFJ4",
+               "RFJ1", "RFJ2", "RFJ3", "RFJ4", "LFJ1", "LFJ2", "LFJ3", "LFJ4", "LFJ5",
+               "THJ1", "THJ2", "THJ3", "THJ4", "THJ5", "WRJ1", "WRJ2"]
+controller_params = ["sr_edc_calibration_controllers.yaml",
+                     "sr_edc_joint_velocity_controllers_PWM.yaml",
+                     "sr_edc_effort_controllers_PWM.yaml",
+                     "sr_edc_joint_velocity_controllers.yaml",
+                     "sr_edc_effort_controllers.yaml",
+                     "sr_edc_mixed_position_velocity_joint_controllers_PWM.yaml",
+                     "sr_edc_joint_position_controllers_PWM.yaml",
+                     "sr_edc_mixed_position_velocity_joint_controllers.yaml",
+                     "sr_edc_joint_position_controllers.yaml"]
 
 
 class TestHandFinder(unittest.TestCase):
+    rospack = rospkg.RosPack()
+    ethercat_path = rospack.get_path('sr_ethercat_hand_config')
+  
     def test_no_hand_no_robot_description_finder(self):
         if rospy.has_param("hand"):
             rospy.delete_param("hand")
@@ -34,23 +50,178 @@ class TestHandFinder(unittest.TestCase):
             rospy.delete_param("robot_description")
 
         rospy.set_param("hand/joint_prefix/1", "rh_")
+        rospy.set_param("hand/mapping/1", "right")
+
+        hand_finder = HandFinder()
+        # hand params
+        self.assertIsNotNone(hand_finder.get_hand_parameters(), "Parameters extracted.")
+        self.assertEqual(len(hand_finder.get_hand_parameters().mapping), 1, "It should be only one mapping")
+        self.assertEqual(len(hand_finder.get_hand_parameters().joint_prefix), 1, "It should be only one joint_prefix")
+        self.assertEqual(hand_finder.get_hand_parameters().mapping['1'], "right", "It should be only right mapping")
+        self.assertEqual(hand_finder.get_hand_parameters().joint_prefix['1'], "rh_", "It should be only rh_ prefix")
+        # hand joints
+        self.assertIsNotNone(hand_finder.get_hand_joints(), "Joints extracted.")
+        self.assertEqual(len(hand_finder.get_hand_joints().keys()), 1, "It should be only one mapping")
+        self.assertIn("right", hand_finder.get_hand_joints(), "Mapping should be in the joints result")
+        joints = hand_finder.get_hand_joints()['right']
+        self.assertEqual(len(joints), 24, "Joint number should be 24")
+        self.assertIn("rh_FFJ3", hand_finder.get_hand_joints()["right"], "FFJ3 joint should be in the joints list")
+        # calibration
+        self.assertIsNotNone(hand_finder.get_calibration_path(), "Calibration extracted.")
+        calibration_path = hand_finder.get_calibration_path()['right']
+        self.assertEqual(calibration_path, self.ethercat_path + "/calibrations/right/" + "calibration.yaml",
+                         "incorrect calibration file")
+        # tuning
+        self.assertIsNotNone(hand_finder.get_hand_control_tuning(), "Control tuning parameters extracted.")
+        ctrl_tun_friction_comp_path = hand_finder.get_hand_control_tuning().friction_compensation['right']
+        self.assertEqual(ctrl_tun_friction_comp_path, self.ethercat_path + "/controls/friction_compensation.yaml",
+                         "incorrect friction compensation file")
+        ctrl_tun_motors_path = hand_finder.get_hand_control_tuning().motor_control['right']
+        self.assertEqual(ctrl_tun_motors_path, self.ethercat_path +
+                         "/controls/motors/right/motor_board_effort_controllers.yaml",
+                         "incorrect motor config file")
+        ctrl_tun_host_control_paths = hand_finder.get_hand_control_tuning().host_control['right']
+        self.assertEqual(len(ctrl_tun_host_control_paths), len(controller_params),
+                         "incorrect number of host controllers param")
+        for controller_path, controller_param in zip(ctrl_tun_host_control_paths, controller_params):
+            self.assertEqual(controller_path, self.ethercat_path + "/controls/host/right/" + controller_param,
+                             "incorrect controller config file")
+
+    def test_one_hand_no_mapping_no_robot_description_finder(self):
+        if rospy.has_param("hand"):
+            rospy.delete_param("hand")
+
+        if rospy.has_param("robot_description"):
+            rospy.delete_param("robot_description")
+
+        rospy.set_param("hand/joint_prefix/1", "rh_")
+        rospy.set_param("hand/mapping/1", "")
+
+        hand_finder = HandFinder()
+        # hand params
+        self.assertIsNotNone(hand_finder.get_hand_parameters(), "Parameters extracted.")
+        self.assertEqual(len(hand_finder.get_hand_parameters().mapping), 1, "It should be only one mapping")
+        self.assertEqual(len(hand_finder.get_hand_parameters().joint_prefix), 1, "It should be only one joint_prefix")
+        self.assertEqual(hand_finder.get_hand_parameters().mapping['1'], "", "It should be only an empty mapping")
+        self.assertEqual(hand_finder.get_hand_parameters().joint_prefix['1'], "rh_", "It should be only rh_ prefix")
+        # hand joints
+        self.assertIsNotNone(hand_finder.get_hand_joints(), "Joints extracted.")
+        self.assertEqual(len(hand_finder.get_hand_joints().keys()), 1, "It should be only one mapping")
+        print hand_finder.get_hand_joints()
+        self.assertIn("1", hand_finder.get_hand_joints(), "Serial should be in the joints result")
+        joints = hand_finder.get_hand_joints()['1'] # use serial
+        self.assertEqual(len(joints), 24, "Joint number should be 24")
+        self.assertIn("rh_FFJ3", hand_finder.get_hand_joints()["1"], "FFJ3 joint should be in the joints list")
+        # calibration
+        self.assertIsNotNone(hand_finder.get_calibration_path(), "Calibration extracted.")
+        calibration_path = hand_finder.get_calibration_path()['1']
+        self.assertEqual(calibration_path, self.ethercat_path + "/calibrations/1/" + "calibration.yaml",
+                         "incorrect calibration file")
+        # tuning
+        self.assertIsNotNone(hand_finder.get_hand_control_tuning(), "Control tuning parameters extracted.")
+        ctrl_tun_friction_comp_path = hand_finder.get_hand_control_tuning().friction_compensation['1']
+        self.assertEqual(ctrl_tun_friction_comp_path, self.ethercat_path + "/controls/friction_compensation.yaml",
+                         "incorrect friction compensation file")
+        ctrl_tun_motors_path = hand_finder.get_hand_control_tuning().motor_control['1']
+        self.assertEqual(ctrl_tun_motors_path, self.ethercat_path +
+                         "/controls/motors/1/motor_board_effort_controllers.yaml",
+                         "incorrect motor config file")
+        ctrl_tun_host_control_paths = hand_finder.get_hand_control_tuning().host_control['1']
+        self.assertEqual(len(ctrl_tun_host_control_paths), len(controller_params),
+                         "incorrect number of host controllers param")
+        for controller_path, controller_param in zip(ctrl_tun_host_control_paths, controller_params):
+            self.assertEqual(controller_path, self.ethercat_path + "/controls/host/1/" + controller_param,
+                             "incorrect controller config file")
+
+    def test_one_hand_no_prefix_no_robot_description_finder(self):
+        if rospy.has_param("hand"):
+            rospy.delete_param("hand")
+
+        if rospy.has_param("robot_description"):
+            rospy.delete_param("robot_description")
+
+        rospy.set_param("hand/joint_prefix/1", "")
         rospy.set_param("hand/mapping/1", "rh")
 
         hand_finder = HandFinder()
+        # hand params
         self.assertIsNotNone(hand_finder.get_hand_parameters(), "Parameters extracted.")
-        self.assertIsNotNone(hand_finder.get_hand_joints(), "Joints extracted.")
-        self.assertIsNotNone(hand_finder.get_calibration_path(), "Calibration extracted.")
-        self.assertIsNotNone(hand_finder.get_hand_control_tuning(), "Control tuning parameters extracted.")
-
         self.assertEqual(len(hand_finder.get_hand_parameters().mapping), 1, "It should be only one mapping")
         self.assertEqual(len(hand_finder.get_hand_parameters().joint_prefix), 1, "It should be only one joint_prefix")
-
-        self.assertEqual(hand_finder.get_hand_parameters().mapping['1'], "rh", "It should be only rh mapping")
-        self.assertEqual(hand_finder.get_hand_parameters().joint_prefix['1'], "rh_", "It should be only rh_ prefix")
-
+        self.assertEqual(hand_finder.get_hand_parameters().mapping['1'], "rh", "It should be only right mapping")
+        self.assertEqual(hand_finder.get_hand_parameters().joint_prefix['1'], "", "It should be only an empty prefix")
+        # hand joints
+        self.assertIsNotNone(hand_finder.get_hand_joints(), "Joints extracted.")
         self.assertEqual(len(hand_finder.get_hand_joints().keys()), 1, "It should be only one mapping")
-        self.assertIn("rh", hand_finder.get_hand_joints(), "Maping should be in the joints result")
-        self.assertIn("rh_FFJ3", hand_finder.get_hand_joints()["rh"], "FFJ3 joint should be in the joints list")
+        self.assertIn("rh", hand_finder.get_hand_joints(), "Mapping should be in the joints result")
+        joints = hand_finder.get_hand_joints()['rh']
+        self.assertEqual(len(joints), 24, "Joint number should be 24")
+        self.assertIn("FFJ3", hand_finder.get_hand_joints()["rh"], "FFJ3 joint should be in the joints list")
+        # calibration
+        self.assertIsNotNone(hand_finder.get_calibration_path(), "Calibration extracted.")
+        calibration_path = hand_finder.get_calibration_path()['rh']
+        self.assertEqual(calibration_path, self.ethercat_path + "/calibrations/rh/" + "calibration.yaml",
+                         "incorrect calibration file")
+        # tuning
+        self.assertIsNotNone(hand_finder.get_hand_control_tuning(), "Control tuning parameters extracted.")
+        ctrl_tun_friction_comp_path = hand_finder.get_hand_control_tuning().friction_compensation['rh']
+        self.assertEqual(ctrl_tun_friction_comp_path, self.ethercat_path + "/controls/friction_compensation.yaml",
+                         "incorrect friction compensation file")
+        ctrl_tun_motors_path = hand_finder.get_hand_control_tuning().motor_control['rh']
+        self.assertEqual(ctrl_tun_motors_path, self.ethercat_path +
+                         "/controls/motors/rh/motor_board_effort_controllers.yaml",
+                         "incorrect motor config file")
+        ctrl_tun_host_control_paths = hand_finder.get_hand_control_tuning().host_control['rh']
+        self.assertEqual(len(ctrl_tun_host_control_paths), len(controller_params),
+                         "incorrect number of host controllers param")
+        for controller_path, controller_param in zip(ctrl_tun_host_control_paths, controller_params):
+            self.assertEqual(controller_path, self.ethercat_path + "/controls/host/rh/" + controller_param,
+                             "incorrect controller config file")
+        
+    def test_one_hand_no_prefix_no_mapping_no_robot_description_finder(self):
+        if rospy.has_param("hand"):
+            rospy.delete_param("hand")
+
+        if rospy.has_param("robot_description"):
+            rospy.delete_param("robot_description")
+
+        rospy.set_param("hand/joint_prefix/1", "")
+        rospy.set_param("hand/mapping/1", "")
+
+        hand_finder = HandFinder()
+        # hand params
+        self.assertIsNotNone(hand_finder.get_hand_parameters(), "Parameters extracted.")
+        self.assertEqual(len(hand_finder.get_hand_parameters().mapping), 1, "It should be only one mapping")
+        self.assertEqual(len(hand_finder.get_hand_parameters().joint_prefix), 1, "It should be only one joint_prefix")
+        self.assertEqual(hand_finder.get_hand_parameters().mapping['1'], "", "It should be only an empty mapping")
+        self.assertEqual(hand_finder.get_hand_parameters().joint_prefix['1'], "", "It should be only an empty prefix")
+        # hand joints
+        self.assertIsNotNone(hand_finder.get_hand_joints(), "Joints extracted.")
+        self.assertEqual(len(hand_finder.get_hand_joints().keys()), 1, "It should be only one mapping")
+        self.assertIn("1", hand_finder.get_hand_joints(), "Serial should be in the joints result")
+        joints = hand_finder.get_hand_joints()['1']
+        self.assertEqual(len(joints), 24, "Joint number should be 24")
+        self.assertIn("FFJ3", hand_finder.get_hand_joints()["1"], "FFJ3 joint should be in the joints list")
+        # calibration
+        self.assertIsNotNone(hand_finder.get_calibration_path(), "Calibration extracted.")
+        calibration_path = hand_finder.get_calibration_path()['1']
+        self.assertEqual(calibration_path, self.ethercat_path + "/calibrations/1/" + "calibration.yaml",
+                         "incorrect calibration file")
+        # tuning
+        self.assertIsNotNone(hand_finder.get_hand_control_tuning(), "Control tuning parameters extracted.")
+        ctrl_tun_friction_comp_path = hand_finder.get_hand_control_tuning().friction_compensation['1']
+        self.assertEqual(ctrl_tun_friction_comp_path, self.ethercat_path + "/controls/friction_compensation.yaml",
+                         "incorrect friction compensation file")
+        ctrl_tun_motors_path = hand_finder.get_hand_control_tuning().motor_control['1']
+        self.assertEqual(ctrl_tun_motors_path, self.ethercat_path +
+                         "/controls/motors/1/motor_board_effort_controllers.yaml",
+                         "incorrect motor config file")
+        ctrl_tun_host_control_paths = hand_finder.get_hand_control_tuning().host_control['1']
+        self.assertEqual(len(ctrl_tun_host_control_paths), len(controller_params),
+                         "incorrect number of host controllers param")
+        for controller_path, controller_param in zip(ctrl_tun_host_control_paths, controller_params):
+            self.assertEqual(controller_path, self.ethercat_path + "/controls/host/1/" + controller_param,
+                             "incorrect controller config file")
 
     def test_two_hand_no_robot_description_finder(self):
         if rospy.has_param("hand"):
@@ -60,28 +231,72 @@ class TestHandFinder(unittest.TestCase):
             rospy.delete_param("robot_description")
 
         rospy.set_param("hand/joint_prefix/1", "rh_")
-        rospy.set_param("hand/mapping/1", "rh")
+        rospy.set_param("hand/mapping/1", "right")
         rospy.set_param("hand/joint_prefix/2", "lh_")
-        rospy.set_param("hand/mapping/2", "lh")
+        rospy.set_param("hand/mapping/2", "left")
 
         hand_finder = HandFinder()
+        
+        # hand params
         self.assertIsNotNone(hand_finder.get_hand_parameters(), "Parameters extracted.")
-        self.assertIsNotNone(hand_finder.get_hand_joints(), "Joints extracted.")
-        self.assertIsNotNone(hand_finder.get_calibration_path(), "Calibration extracted.")
-        self.assertIsNotNone(hand_finder.get_hand_control_tuning(), "Control tuning parameters extracted.")
-
         self.assertEqual(len(hand_finder.get_hand_parameters().mapping), 2, "It should be two mappings")
+        self.assertIn("right", hand_finder.get_hand_parameters().mapping.values(), "It should be right mapping")
+        self.assertIn("left", hand_finder.get_hand_parameters().mapping.values(), "It should be left mapping")
         self.assertEqual(len(hand_finder.get_hand_parameters().joint_prefix), 2, "It should be two joint_prefixes")
-        self.assertIn("rh", hand_finder.get_hand_parameters().mapping.values(), "It should be rh mapping")
-        self.assertIn("lh", hand_finder.get_hand_parameters().mapping.values(), "It should be lh mapping")
+  
         self.assertIn("rh_", hand_finder.get_hand_parameters().joint_prefix.values(), "It should be rh_ prefix")
         self.assertIn("lh_", hand_finder.get_hand_parameters().joint_prefix.values(), "It should be rh_ prefix")
-
+        
+        # hand joints
+        self.assertIsNotNone(hand_finder.get_hand_joints(), "Joints extracted.")
         self.assertEqual(len(hand_finder.get_hand_joints().keys()), 2, "It should be two mappings")
-        self.assertIn("rh", hand_finder.get_hand_joints(), "Maping should be in the joints result")
-        self.assertIn("rh_FFJ3", hand_finder.get_hand_joints()["rh"], "FFJ3 joint should be in the joints list")
-        self.assertIn("lh", hand_finder.get_hand_joints(), "Maping should be in the joints result")
-        self.assertIn("lh_FFJ1", hand_finder.get_hand_joints()["lh"], "FFJ3 joint should be in the joints list")
+        self.assertIn("right", hand_finder.get_hand_joints(), "Mapping should be in the joints result")
+        joints = hand_finder.get_hand_joints()['right']
+        self.assertEqual(len(joints), 24, "Joint number should be 24")
+        self.assertIn("rh_FFJ3", hand_finder.get_hand_joints()["right"], "FFJ3 joint should be in the joints list")
+        self.assertIn("left", hand_finder.get_hand_joints(), "Mapping should be in the joints result")
+        joints = hand_finder.get_hand_joints()['left']
+        self.assertEqual(len(joints), 24, "Joint number should be 24")
+        self.assertIn("lh_FFJ1", hand_finder.get_hand_joints()["left"], "FFJ1 joint should be in the joints list")
+        
+        # calibration
+        self.assertIsNotNone(hand_finder.get_calibration_path(), "Calibration extracted.")
+        calibration_path = hand_finder.get_calibration_path()['right']
+        self.assertEqual(calibration_path, self.ethercat_path + "/calibrations/right/" + "calibration.yaml",
+                         "incorrect calibration file")
+        calibration_path = hand_finder.get_calibration_path()['left']
+        self.assertEqual(calibration_path, self.ethercat_path + "/calibrations/left/" + "calibration.yaml",
+                         "incorrect calibration file")
+        # tuning
+        self.assertIsNotNone(hand_finder.get_hand_control_tuning(), "Control tuning parameters extracted.")
+        ctrl_tun_friction_comp_path = hand_finder.get_hand_control_tuning().friction_compensation['right']
+        self.assertEqual(ctrl_tun_friction_comp_path, self.ethercat_path + "/controls/friction_compensation.yaml",
+                         "incorrect friction compensation file")
+        ctrl_tun_motors_path = hand_finder.get_hand_control_tuning().motor_control['right']
+        self.assertEqual(ctrl_tun_motors_path, self.ethercat_path +
+                         "/controls/motors/right/motor_board_effort_controllers.yaml",
+                         "incorrect motor config file")
+        ctrl_tun_host_control_paths = hand_finder.get_hand_control_tuning().host_control['right']
+        self.assertEqual(len(ctrl_tun_host_control_paths), len(controller_params),
+                         "incorrect number of host controllers param")
+        for controller_path, controller_param in zip(ctrl_tun_host_control_paths, controller_params):
+            self.assertEqual(controller_path, self.ethercat_path + "/controls/host/right/" + controller_param,
+                             "incorrect controller config file")
+                             
+        ctrl_tun_friction_comp_path = hand_finder.get_hand_control_tuning().friction_compensation['left']
+        self.assertEqual(ctrl_tun_friction_comp_path, self.ethercat_path + "/controls/friction_compensation.yaml",
+                         "incorrect friction compensation file")
+        ctrl_tun_motors_path = hand_finder.get_hand_control_tuning().motor_control['left']
+        self.assertEqual(ctrl_tun_motors_path, self.ethercat_path +
+                         "/controls/motors/left/motor_board_effort_controllers.yaml",
+                         "incorrect motor config file")
+        ctrl_tun_host_control_paths = hand_finder.get_hand_control_tuning().host_control['left']
+        self.assertEqual(len(ctrl_tun_host_control_paths), len(controller_params),
+                         "incorrect number of host controllers param")
+        for controller_path, controller_param in zip(ctrl_tun_host_control_paths, controller_params):
+            self.assertEqual(controller_path, self.ethercat_path + "/controls/host/left/" + controller_param,
+                             "incorrect controller config file")
+
 
     def test_no_hand_robot_description_exists_finder(self):
         if rospy.has_param("hand"):
@@ -104,69 +319,269 @@ class TestHandFinder(unittest.TestCase):
         self.assertEqual(len(hand_finder.get_hand_control_tuning(). motor_control), 0,
                          "correct tuning without a hands")
 
-    def test_one_hand_robot_description_exists_finder(self):
+    def test_one_hand_robot_description_exists_finder(self):        
         if rospy.has_param("hand"):
             rospy.delete_param("hand")
 
         if rospy.has_param("robot_description"):
             rospy.delete_param("robot_description")
 
+        rospy.set_param("hand/joint_prefix/1", "rh_")
+        rospy.set_param("hand/mapping/1", "right")
         rospy.set_param("robot_description", rospy.get_param("right_hand_description"))
 
-        rospy.set_param("hand/joint_prefix/1", "rh_")
-        rospy.set_param("hand/mapping/1", "rh")
-
         hand_finder = HandFinder()
+        # hand params
         self.assertIsNotNone(hand_finder.get_hand_parameters(), "Parameters extracted.")
-        self.assertIsNotNone(hand_finder.get_hand_joints(), "Joints extracted.")
-        self.assertIsNotNone(hand_finder.get_calibration_path(), "Calibration extracted.")
-        self.assertIsNotNone(hand_finder.get_hand_control_tuning(), "Control tuning parameters extracted.")
-
         self.assertEqual(len(hand_finder.get_hand_parameters().mapping), 1, "It should be only one mapping")
         self.assertEqual(len(hand_finder.get_hand_parameters().joint_prefix), 1, "It should be only one joint_prefix")
-
-        self.assertEqual(hand_finder.get_hand_parameters().mapping['1'], "rh", "It should be only rh mapping")
+        self.assertEqual(hand_finder.get_hand_parameters().mapping['1'], "right", "It should be only right mapping")
         self.assertEqual(hand_finder.get_hand_parameters().joint_prefix['1'], "rh_", "It should be only rh_ prefix")
-
+        # hand joints
+        self.assertIsNotNone(hand_finder.get_hand_joints(), "Joints extracted.")
         self.assertEqual(len(hand_finder.get_hand_joints().keys()), 1, "It should be only one mapping")
-        self.assertIn("rh", hand_finder.get_hand_joints(), "Maping should be in the joints result")
-        self.assertNotIn("rh_FFJ3", hand_finder.get_hand_joints()["rh"], "FFJ3 joint should not be in the joints list")
-        self.assertIn("rh_RFJ4", hand_finder.get_hand_joints()["rh"], "RFJ4 joint should be in the joints list")
+        self.assertIn("right", hand_finder.get_hand_joints(), "Mapping should be in the joints result")
+        joints = hand_finder.get_hand_joints()['right']
+        self.assertEqual(len(joints), 1, "Joint number should be 1")
+        self.assertNotIn("rh_FFJ3", hand_finder.get_hand_joints()["right"], "FFJ3 joint should not be in the joints list")
+        self.assertIn("rh_RFJ4", hand_finder.get_hand_joints()["right"], "RFJ4 joint should be in the joints list")
+        # calibration
+        self.assertIsNotNone(hand_finder.get_calibration_path(), "Calibration extracted.")
+        calibration_path = hand_finder.get_calibration_path()['right']
+        self.assertEqual(calibration_path, self.ethercat_path + "/calibrations/right/" + "calibration.yaml",
+                         "incorrect calibration file")
+        # tuning
+        self.assertIsNotNone(hand_finder.get_hand_control_tuning(), "Control tuning parameters extracted.")
+        ctrl_tun_friction_comp_path = hand_finder.get_hand_control_tuning().friction_compensation['right']
+        self.assertEqual(ctrl_tun_friction_comp_path, self.ethercat_path + "/controls/friction_compensation.yaml",
+                         "incorrect friction compensation file")
+        ctrl_tun_motors_path = hand_finder.get_hand_control_tuning().motor_control['right']
+        self.assertEqual(ctrl_tun_motors_path, self.ethercat_path +
+                         "/controls/motors/right/motor_board_effort_controllers.yaml",
+                         "incorrect motor config file")
+        ctrl_tun_host_control_paths = hand_finder.get_hand_control_tuning().host_control['right']
+        self.assertEqual(len(ctrl_tun_host_control_paths), len(controller_params),
+                         "incorrect number of host controllers param")
+        for controller_path, controller_param in zip(ctrl_tun_host_control_paths, controller_params):
+            self.assertEqual(controller_path, self.ethercat_path + "/controls/host/right/" + controller_param,
+                             "incorrect controller config file")
 
-    def test_two_hand_robot_description_exists_finder(self):
+    def test_one_hand_no_mapping_robot_description_exists_finder(self):
         if rospy.has_param("hand"):
             rospy.delete_param("hand")
 
         if rospy.has_param("robot_description"):
             rospy.delete_param("robot_description")
 
-        rospy.set_param("robot_description", rospy.get_param("two_hands_description"))
-
         rospy.set_param("hand/joint_prefix/1", "rh_")
-        rospy.set_param("hand/mapping/1", "rh")
-        rospy.set_param("hand/joint_prefix/2", "lh_")
-        rospy.set_param("hand/mapping/2", "lh")
+        rospy.set_param("hand/mapping/1", "")
+        rospy.set_param("robot_description", rospy.get_param("right_hand_description"))
 
         hand_finder = HandFinder()
+        # hand params
         self.assertIsNotNone(hand_finder.get_hand_parameters(), "Parameters extracted.")
+        self.assertEqual(len(hand_finder.get_hand_parameters().mapping), 1, "It should be only one mapping")
+        self.assertEqual(len(hand_finder.get_hand_parameters().joint_prefix), 1, "It should be only one joint_prefix")
+        self.assertEqual(hand_finder.get_hand_parameters().mapping['1'], "", "It should be only an empty mapping")
+        self.assertEqual(hand_finder.get_hand_parameters().joint_prefix['1'], "rh_", "It should be only rh_ prefix")
+        # hand joints
         self.assertIsNotNone(hand_finder.get_hand_joints(), "Joints extracted.")
+        self.assertEqual(len(hand_finder.get_hand_joints().keys()), 1, "It should be only one mapping")
+        self.assertIn("1", hand_finder.get_hand_joints(), "Mapping should be in the joints result")
+        joints = hand_finder.get_hand_joints()['1']
+        self.assertEqual(len(joints), 1, "Joint number should be 1")
+        self.assertNotIn("rh_FFJ3", hand_finder.get_hand_joints()["1"], "FFJ3 joint should not be in the joints list")
+        self.assertIn("rh_RFJ4", hand_finder.get_hand_joints()["1"], "RFJ4 joint should be in the joints list")
+        # calibration
         self.assertIsNotNone(hand_finder.get_calibration_path(), "Calibration extracted.")
+        calibration_path = hand_finder.get_calibration_path()['1']
+        self.assertEqual(calibration_path, self.ethercat_path + "/calibrations/1/" + "calibration.yaml",
+                         "incorrect calibration file")
+        # tuning
         self.assertIsNotNone(hand_finder.get_hand_control_tuning(), "Control tuning parameters extracted.")
+        ctrl_tun_friction_comp_path = hand_finder.get_hand_control_tuning().friction_compensation['1']
+        self.assertEqual(ctrl_tun_friction_comp_path, self.ethercat_path + "/controls/friction_compensation.yaml",
+                         "incorrect friction compensation file")
+        ctrl_tun_motors_path = hand_finder.get_hand_control_tuning().motor_control['1']
+        self.assertEqual(ctrl_tun_motors_path, self.ethercat_path +
+                         "/controls/motors/1/motor_board_effort_controllers.yaml",
+                         "incorrect motor config file")
+        ctrl_tun_host_control_paths = hand_finder.get_hand_control_tuning().host_control['1']
+        self.assertEqual(len(ctrl_tun_host_control_paths), len(controller_params),
+                         "incorrect number of host controllers param")
+        for controller_path, controller_param in zip(ctrl_tun_host_control_paths, controller_params):
+            self.assertEqual(controller_path, self.ethercat_path + "/controls/host/1/" + controller_param,
+                             "incorrect controller config file")
+    
+    def test_one_hand_no_prefix_robot_description_exists_finder(self):
+        if rospy.has_param("hand"):
+            rospy.delete_param("hand")
 
+        if rospy.has_param("robot_description"):
+            rospy.delete_param("robot_description")
+
+        rospy.set_param("hand/joint_prefix/1", "")
+        rospy.set_param("hand/mapping/1", "rh")
+        rospy.set_param("robot_description", rospy.get_param("right_hand_description"))
+
+        hand_finder = HandFinder()
+        # hand params
+        self.assertIsNotNone(hand_finder.get_hand_parameters(), "Parameters extracted.")
+        self.assertEqual(len(hand_finder.get_hand_parameters().mapping), 1, "It should be only one mapping")
+        self.assertEqual(len(hand_finder.get_hand_parameters().joint_prefix), 1, "It should be only one joint_prefix")
+        self.assertEqual(hand_finder.get_hand_parameters().mapping['1'], "rh", "It should be only right mapping")
+        self.assertEqual(hand_finder.get_hand_parameters().joint_prefix['1'], "", "It should be only an empty prefix")
+        # hand joints
+        self.assertIsNotNone(hand_finder.get_hand_joints(), "Joints extracted.")
+        self.assertEqual(len(hand_finder.get_hand_joints().keys()), 1, "It should be only one mapping")
+        self.assertIn("rh", hand_finder.get_hand_joints(), "Mapping should be in the joints result")
+        joints = hand_finder.get_hand_joints()['rh']
+        self.assertEqual(len(joints), 1, "Joint number should be 1")
+        self.assertNotIn("FFJ3", hand_finder.get_hand_joints()["rh"], "FFJ3 joint should not be in the joints list")
+        self.assertIn("RFJ4", hand_finder.get_hand_joints()["rh"], "RFJ4 joint should be in the joints list")
+        # calibration
+        self.assertIsNotNone(hand_finder.get_calibration_path(), "Calibration extracted.")
+        calibration_path = hand_finder.get_calibration_path()['rh']
+        self.assertEqual(calibration_path, self.ethercat_path + "/calibrations/rh/" + "calibration.yaml",
+                         "incorrect calibration file")
+        # tuning
+        self.assertIsNotNone(hand_finder.get_hand_control_tuning(), "Control tuning parameters extracted.")
+        ctrl_tun_friction_comp_path = hand_finder.get_hand_control_tuning().friction_compensation['rh']
+        self.assertEqual(ctrl_tun_friction_comp_path, self.ethercat_path + "/controls/friction_compensation.yaml",
+                         "incorrect friction compensation file")
+        ctrl_tun_motors_path = hand_finder.get_hand_control_tuning().motor_control['rh']
+        self.assertEqual(ctrl_tun_motors_path, self.ethercat_path +
+                         "/controls/motors/rh/motor_board_effort_controllers.yaml",
+                         "incorrect motor config file")
+        ctrl_tun_host_control_paths = hand_finder.get_hand_control_tuning().host_control['rh']
+        self.assertEqual(len(ctrl_tun_host_control_paths), len(controller_params),
+                         "incorrect number of host controllers param")
+        for controller_path, controller_param in zip(ctrl_tun_host_control_paths, controller_params):
+            self.assertEqual(controller_path, self.ethercat_path + "/controls/host/rh/" + controller_param,
+                             "incorrect controller config file")
+        
+    def test_one_hand_no_prefix_no_ns_robot_description_exists_finder(self):
+        if rospy.has_param("hand"):
+            rospy.delete_param("hand")
+
+        if rospy.has_param("robot_description"):
+            rospy.delete_param("robot_description")
+
+        rospy.set_param("hand/joint_prefix/1", "")
+        rospy.set_param("hand/mapping/1", "")
+        rospy.set_param("robot_description", rospy.get_param("right_hand_description"))
+
+        hand_finder = HandFinder()
+        # hand params
+        self.assertIsNotNone(hand_finder.get_hand_parameters(), "Parameters extracted.")
+        self.assertEqual(len(hand_finder.get_hand_parameters().mapping), 1, "It should be only one mapping")
+        self.assertEqual(len(hand_finder.get_hand_parameters().joint_prefix), 1, "It should be only one joint_prefix")
+        self.assertEqual(hand_finder.get_hand_parameters().mapping['1'], "", "It should be only an empty mapping")
+        self.assertEqual(hand_finder.get_hand_parameters().joint_prefix['1'], "", "It should be only an empty prefix")
+        # hand joints
+        self.assertIsNotNone(hand_finder.get_hand_joints(), "Joints extracted.")
+        self.assertEqual(len(hand_finder.get_hand_joints().keys()), 1, "It should be only one mapping")
+        self.assertIn("1", hand_finder.get_hand_joints(), "Mapping should be in the joints result")
+        joints = hand_finder.get_hand_joints()['1']
+        self.assertEqual(len(joints), 1, "Joint number should be 1")
+        self.assertNotIn("FFJ3", hand_finder.get_hand_joints()["1"], "FFJ3 joint should not be in the joints list")
+        self.assertIn("RFJ4", hand_finder.get_hand_joints()["1"], "RFJ4 joint should be in the joints list")
+        # calibration
+        self.assertIsNotNone(hand_finder.get_calibration_path(), "Calibration extracted.")
+        calibration_path = hand_finder.get_calibration_path()['1']
+        self.assertEqual(calibration_path, self.ethercat_path + "/calibrations/1/" + "calibration.yaml",
+                         "incorrect calibration file")
+        # tuning
+        self.assertIsNotNone(hand_finder.get_hand_control_tuning(), "Control tuning parameters extracted.")
+        ctrl_tun_friction_comp_path = hand_finder.get_hand_control_tuning().friction_compensation['1']
+        self.assertEqual(ctrl_tun_friction_comp_path, self.ethercat_path + "/controls/friction_compensation.yaml",
+                         "incorrect friction compensation file")
+        ctrl_tun_motors_path = hand_finder.get_hand_control_tuning().motor_control['1']
+        self.assertEqual(ctrl_tun_motors_path, self.ethercat_path +
+                         "/controls/motors/1/motor_board_effort_controllers.yaml",
+                         "incorrect motor config file")
+        ctrl_tun_host_control_paths = hand_finder.get_hand_control_tuning().host_control['1']
+        self.assertEqual(len(ctrl_tun_host_control_paths), len(controller_params),
+                         "incorrect number of host controllers param")
+        for controller_path, controller_param in zip(ctrl_tun_host_control_paths, controller_params):
+            self.assertEqual(controller_path, self.ethercat_path + "/controls/host/1/" + controller_param,
+                             "incorrect controller config file")
+
+    def test_two_hand_robot_description_exists_finder(self):    
+        if rospy.has_param("hand"):
+            rospy.delete_param("hand")
+
+        if rospy.has_param("robot_description"):
+            rospy.delete_param("robot_description")
+
+        rospy.set_param("hand/joint_prefix/1", "rh_")
+        rospy.set_param("hand/mapping/1", "right")
+        rospy.set_param("hand/joint_prefix/2", "lh_")
+        rospy.set_param("hand/mapping/2", "left")
+        rospy.set_param("robot_description", rospy.get_param("two_hands_description"))
+
+        hand_finder = HandFinder()
+        # hand params
+        self.assertIsNotNone(hand_finder.get_hand_parameters(), "Parameters extracted.")
         self.assertEqual(len(hand_finder.get_hand_parameters().mapping), 2, "It should be two mappings")
+        self.assertIn("right", hand_finder.get_hand_parameters().mapping.values(), "It should be right mapping")
+        self.assertIn("left", hand_finder.get_hand_parameters().mapping.values(), "It should be left mapping")
         self.assertEqual(len(hand_finder.get_hand_parameters().joint_prefix), 2, "It should be two joint_prefixes")
-        self.assertIn("rh", hand_finder.get_hand_parameters().mapping.values(), "It should be rh mapping")
-        self.assertIn("lh", hand_finder.get_hand_parameters().mapping.values(), "It should be lh mapping")
+  
         self.assertIn("rh_", hand_finder.get_hand_parameters().joint_prefix.values(), "It should be rh_ prefix")
         self.assertIn("lh_", hand_finder.get_hand_parameters().joint_prefix.values(), "It should be rh_ prefix")
-
+        
+        # hand joints
+        self.assertIsNotNone(hand_finder.get_hand_joints(), "Joints extracted.")
         self.assertEqual(len(hand_finder.get_hand_joints().keys()), 2, "It should be two mappings")
-        self.assertIn("rh", hand_finder.get_hand_joints(), "Maping should be in the joints result")
-        self.assertNotIn("rh_FFJ3", hand_finder.get_hand_joints()["rh"], "FFJ3 joint should not be in the joints list")
-        self.assertIn("rh_RFJ4", hand_finder.get_hand_joints()["rh"], "RFJ4 joint should be in the joints list")
-        self.assertIn("lh", hand_finder.get_hand_joints(), "Maping should be in the joints result")
-        self.assertNotIn("lh_FFJ1", hand_finder.get_hand_joints()["lh"], "FFJ3 joint should not be in the joints list")
-        self.assertIn("lh_LFJ4", hand_finder.get_hand_joints()["lh"], "LFJ4 joint should be in the joints list")
+        self.assertIn("right", hand_finder.get_hand_joints(), "Mapping should be in the joints result")
+        joints = hand_finder.get_hand_joints()['right']
+        self.assertEqual(len(joints), 1, "Joint number should be 1")
+        self.assertNotIn("rh_FFJ3", hand_finder.get_hand_joints()["right"], "FFJ3 joint should not be in the joints list")
+        self.assertIn("rh_RFJ4", hand_finder.get_hand_joints()["right"], "RFJ4 joint should be in the joints list")
+        self.assertIn("left", hand_finder.get_hand_joints(), "Mapping should be in the joints result")
+        joints = hand_finder.get_hand_joints()['left']
+        self.assertEqual(len(joints), 1, "Joint number should be 1")
+        self.assertNotIn("lh_FFJ3", hand_finder.get_hand_joints()["left"], "FFJ3 joint should not be in the joints list")
+        self.assertIn("lh_RFJ4", hand_finder.get_hand_joints()["left"], "RFJ4 joint should be in the joints list")
+        
+        # calibration
+        self.assertIsNotNone(hand_finder.get_calibration_path(), "Calibration extracted.")
+        calibration_path = hand_finder.get_calibration_path()['right']
+        self.assertEqual(calibration_path, self.ethercat_path + "/calibrations/right/" + "calibration.yaml",
+                         "incorrect calibration file")
+        calibration_path = hand_finder.get_calibration_path()['left']
+        self.assertEqual(calibration_path, self.ethercat_path + "/calibrations/left/" + "calibration.yaml",
+                         "incorrect calibration file")
+        # tuning
+        self.assertIsNotNone(hand_finder.get_hand_control_tuning(), "Control tuning parameters extracted.")
+        ctrl_tun_friction_comp_path = hand_finder.get_hand_control_tuning().friction_compensation['right']
+        self.assertEqual(ctrl_tun_friction_comp_path, self.ethercat_path + "/controls/friction_compensation.yaml",
+                         "incorrect friction compensation file")
+        ctrl_tun_motors_path = hand_finder.get_hand_control_tuning().motor_control['right']
+        self.assertEqual(ctrl_tun_motors_path, self.ethercat_path +
+                         "/controls/motors/right/motor_board_effort_controllers.yaml",
+                         "incorrect motor config file")
+        ctrl_tun_host_control_paths = hand_finder.get_hand_control_tuning().host_control['right']
+        self.assertEqual(len(ctrl_tun_host_control_paths), len(controller_params),
+                         "incorrect number of host controllers param")
+        for controller_path, controller_param in zip(ctrl_tun_host_control_paths, controller_params):
+            self.assertEqual(controller_path, self.ethercat_path + "/controls/host/right/" + controller_param,
+                             "incorrect controller config file")
+                             
+        ctrl_tun_friction_comp_path = hand_finder.get_hand_control_tuning().friction_compensation['left']
+        self.assertEqual(ctrl_tun_friction_comp_path, self.ethercat_path + "/controls/friction_compensation.yaml",
+                         "incorrect friction compensation file")
+        ctrl_tun_motors_path = hand_finder.get_hand_control_tuning().motor_control['left']
+        self.assertEqual(ctrl_tun_motors_path, self.ethercat_path +
+                         "/controls/motors/left/motor_board_effort_controllers.yaml",
+                         "incorrect motor config file")
+        ctrl_tun_host_control_paths = hand_finder.get_hand_control_tuning().host_control['left']
+        self.assertEqual(len(ctrl_tun_host_control_paths), len(controller_params),
+                         "incorrect number of host controllers param")
+        for controller_path, controller_param in zip(ctrl_tun_host_control_paths, controller_params):
+            self.assertEqual(controller_path, self.ethercat_path + "/controls/host/left/" + controller_param,
+                             "incorrect controller config file")
 
 if __name__ == "__main__":
     rospy.init_node("test_hand_finder")

--- a/sr_utilities/test/test_hand_finder.test
+++ b/sr_utilities/test/test_hand_finder.test
@@ -1,6 +1,7 @@
 <launch>
   <param name="no_hand_description" textfile="$(find sr_utilities)/test/urdf/no_hand_description.urdf" />
   <param name="right_hand_description" textfile="$(find sr_utilities)/test/urdf/right_hand_description.urdf" />
+  <param name="right_hand_description_no_prefix" textfile="$(find sr_utilities)/test/urdf/right_hand_description_no_prefix.urdf" />
   <param name="two_hands_description" textfile="$(find sr_utilities)/test/urdf/two_hands_description.urdf" />
 
   <test test-name="test_hand_finder_cpp" pkg="sr_utilities" type="test_hand_finder"/>

--- a/sr_utilities/test/urdf/right_hand_description_no_prefix.urdf
+++ b/sr_utilities/test/urdf/right_hand_description_no_prefix.urdf
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<robot name="one_hand_robot">
+  <link name="base_link">
+    <visual>
+      <geometry>
+        <cylinder length="1.0" radius="0.1"/>
+      </geometry>
+    </visual>
+  </link>
+
+  <link name="palm_link">
+    <visual>
+      <geometry>
+        <cylinder length="1.0" radius="0.1"/>
+      </geometry>
+    </visual>
+  </link>
+
+  <joint name="palm" type="continuous">
+    <parent link="base_link"/>
+    <child link="palm_link"/>
+  </joint>
+
+  <link name="RFJ4_link">
+    <visual>
+      <geometry>
+        <cylinder length="0.1" radius="0.01"/>
+      </geometry>
+    </visual>
+  </link>
+
+  <joint name="RFJ4" type="continuous">
+    <parent link="palm_link"/>
+    <child link="RFJ4_link"/>
+  </joint>
+
+</robot>


### PR DESCRIPTION
fixes #34 

First commits add tests that highlight issues
Next commits solve one bug at a time (almost)
- bug if no hand mapping at all and no robot description
- bug mix-up of hand_id and joint_prefix
- bug with wrong keys used
- empty hand_id support
- fixes after tested on real hand (robot_description)
- bug with hand param not looked globally
- bug with calibrate lockup at start (race condition)
