### PR TITLE
Add wait for topic to trajectory_controller_spawner

### DIFF
--- a/sr_utilities/scripts/sr_utilities/calibrate_hand_finder.py
+++ b/sr_utilities/scripts/sr_utilities/calibrate_hand_finder.py
@@ -45,9 +45,11 @@ class CalibrateWithHand(Calibrate):
 def main():
     if rospy.is_shutdown():
         return
+
+    rospy.init_node('calibration', anonymous=True)
+
     calibrate_class = CalibrateWithHand()
     controllers = calibrate_class.generate_controllers()
-    rospy.init_node('calibration', anonymous=True)
 
     calibrate_class.pub_calibrated.publish(False)
     # Don't calibrate the IMU unless ordered to by user

--- a/sr_utilities/scripts/sr_utilities/trajectory_controller_spawner.py
+++ b/sr_utilities/scripts/sr_utilities/trajectory_controller_spawner.py
@@ -136,7 +136,7 @@ class TrajectoryControllerSpawner(object):
     def wait_for_topic(topic_name, timeout):
         if not topic_name:
             return True
-        
+
         # This has to be a list since Python has a peculiar mechanism to determine
         # whether a variable is local to a function or not:
         # if the variable is assigned in the body of the function, then it is
@@ -159,7 +159,7 @@ class TrajectoryControllerSpawner(object):
             if not warned_about_not_hearing_anything:
                 if rospy.Time.now().to_sec() - started_waiting > timeout:
                     warned_about_not_hearing_anything = True
-                    rospy.logwarn("Controller Spawner hasn't heard anything from its \"wait for\" topic (%s)" % \
+                    rospy.logwarn("Controller Spawner hasn't heard anything from its \"wait for\" topic (%s)" %
                                   topic_name)
         while not wait_for_topic_result[0].data:
             rospy.sleep(0.01)

--- a/sr_utilities/scripts/sr_utilities/trajectory_controller_spawner.py
+++ b/sr_utilities/scripts/sr_utilities/trajectory_controller_spawner.py
@@ -134,11 +134,9 @@ class TrajectoryControllerSpawner(object):
 
     @staticmethod
     def wait_for_topic(topic_name, timeout):
-        rospy.logwarn("topic name: %s" % topic_name)
         if not topic_name:
-            rospy.logwarn("here")
             return True
-        rospy.logwarn("outside")
+        
         # This has to be a list since Python has a peculiar mechanism to determine
         # whether a variable is local to a function or not:
         # if the variable is assigned in the body of the function, then it is


### PR DESCRIPTION
This seems to fix the bug that made the hand launch fail.
Not sure what was actually happening inside the realtime_loop node, but it seems to be triggered by spawning the position controllers before the calibration controllers.

Anyway, the wait_for feature was always there when we were using the standard `controller_manager/spawner`. Only recently, when we created `trajectory_controller_spawner` the wait_for feature wasn't included.

fixes #44 
