### PR TITLE
add GAZEBO_CXX_FLAGS

### DIFF
--- a/sr_gazebo_sim/CMakeLists.txt
+++ b/sr_gazebo_sim/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 2.8.12)
 project(sr_gazebo_sim)
 
 find_package(catkin REQUIRED COMPONENTS roscpp sr_hardware_interface cmake_modules ros_ethercat_model gazebo_ros_control)
@@ -6,6 +6,8 @@ find_package(TinyXML REQUIRED)
 find_package(gazebo REQUIRED)
 
 include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS} ${TinyXML_INCLUDE_DIRS} ${GAZEBO_INCLUDE_DIRS} ${SDFormat_INCLUDE_DIRS})
+
+add_compile_options(${GAZEBO_CXX_FLAGS})
 
 catkin_package(
         DEPENDS TinyXML


### PR DESCRIPTION
Current gazebo requires --std=c++11 and they added this cmake variable to
handle that.

cmake 2.8.12 is already available in ubuntu 14.04., so bumping the version for
add_compile_options is not a problem.
