### PR TITLE
controller_freeze

### DIFF
--- a/sr_mechanism_controllers/doc/README.md
+++ b/sr_mechanism_controllers/doc/README.md
@@ -1,0 +1,33 @@
+# Controllers detail
+
+## srh_mixed_position_velocity_controller
+
+### Overview 
+
+This controller consist of two nested loops. A position PID controller, closing the loop with the current position of the joint, sends velocity requests to a velocity controller
+The velocity PID controller closes the loop with the current measured velocity of the joint, and sends effort commands to the joint interface.
+
+On the shadow hand, the effort is forwarded via the driver to the motor boards.
+
+### Specificities
+
+#### Deadbands
+
+override_to_current_effort parameter is required when a joint moves has a lot of backlash, and shows high variation in the friction profile within the motor/tendon system.
+
+When override_to_current_effort is true, the current effort when entering the deadband is used as the force to maintain when in the deadband,
+ instead of the current command when entering the deadband. 
+ 
+Joint axis that suffer from gravity (like wrist joints), might not want to use this option, as it produces some jerk when entering the deadband under external forces.
+
+default value is false
+
+
+#### Min force threshold
+
+motor_min_force_threshold parameter is used to not command the effort to the joint, if below a certain value. This value should match the threshold for backlash compensation detection
+Indeed, it makes to sense to command an effort of 20 units if the backlash compensation is trigger the motor fullspeed until 40 units are reached (to wind back in the backlash zone as quickly as possible)
+
+If backlash compensation is deactivated, the motor_min_force_threshold should be zero.
+
+

--- a/sr_mechanism_controllers/include/sr_mechanism_controllers/srh_mixed_position_velocity_controller.hpp
+++ b/sr_mechanism_controllers/include/sr_mechanism_controllers/srh_mixed_position_velocity_controller.hpp
@@ -73,6 +73,10 @@ private:
   /// The values for the velocity demand saturation
   double max_velocity_, min_velocity_;
 
+  /// Stores if was previously in the deadband
+  bool prev_in_deadband_;
+  double maintained_command_;
+
 #ifdef DEBUG_PUBLISHER
   ros::Publisher debug_pub;
 #endif

--- a/sr_mechanism_controllers/include/sr_mechanism_controllers/srh_mixed_position_velocity_controller.hpp
+++ b/sr_mechanism_controllers/include/sr_mechanism_controllers/srh_mixed_position_velocity_controller.hpp
@@ -76,6 +76,8 @@ private:
   /// Stores if was previously in the deadband
   bool prev_in_deadband_;
   double maintained_command_;
+  /// Override commanded_effort to current effort when in deadband
+  bool override_to_current_effort_;
 
 #ifdef DEBUG_PUBLISHER
   ros::Publisher debug_pub;


### PR DESCRIPTION
This fixes an issue regarding big motors with tensioner (THJ4/THJ5) and some motors with assymetric gauge reading (THJ1 in our case) that cannot be reacting fast AND precisely stopping at desired pos.

The main reason is that motors move when the force demand is high but the reading is low (no good force tracking on those motors). Hence, when the motor starts to move, and pos reaches the deadband, the force demand is maintained, but this force is higher than the reading and the motor continues moving due to this force demand not being reached and still increasing 

Solution is now to reduce the force demand to current force reading when ever entering the deadband.

Tests (with curves sent to your team) proved that this change does not affect the other motors that almost correctly track, so setting to current force or current demand is almost the same.
