### PR TITLE
B#69 clamp correct range

### DIFF
--- a/sr_mechanism_controllers/include/sr_mechanism_controllers/sr_controller.hpp
+++ b/sr_mechanism_controllers/include/sr_mechanism_controllers/sr_controller.hpp
@@ -101,7 +101,19 @@ protected:
 
   /**
    * Clamps the command to the correct range
-   * (between min and max).
+   * (between min_cmd and max_cmd).
+   *
+   * @param cmd the command we want to clamp
+   * @param min_cmd the min to clamp to
+   * @param max_cmd the max to clamp to
+   *
+   * @return the clamped command
+   */
+  double clamp_command(double cmd, double min_cmd, double max_cmd);
+
+  /**
+   * Clamps the command to the correct range
+   * (between angular min and max).
    *
    * @param cmd the command we want to clamp
    *
@@ -120,6 +132,10 @@ protected:
 
   /// Min and max range of the joint, used to clamp the command.
   double min_, max_;
+  /// Min and max range of the velocity, used to clamp the command.
+  double vel_min_, vel_max_;
+  /// Min and max range of the effort, used to clamp the command.
+  double eff_min_, eff_max_;
 
   int loop_count_;
   bool initialized_;

--- a/sr_mechanism_controllers/include/sr_mechanism_controllers/srh_joint_effort_controller.hpp
+++ b/sr_mechanism_controllers/include/sr_mechanism_controllers/srh_joint_effort_controller.hpp
@@ -59,6 +59,9 @@ private:
   /// read all the controller settings from the parameter server
   void read_parameters();
 
+  /// clamp the command to effort limits
+  double clamp_command(double cmd);
+
   /// set the effort target from a topic
   void setCommandCB(const std_msgs::Float64ConstPtr &msg);
 };

--- a/sr_mechanism_controllers/include/sr_mechanism_controllers/srh_joint_velocity_controller.hpp
+++ b/sr_mechanism_controllers/include/sr_mechanism_controllers/srh_joint_velocity_controller.hpp
@@ -68,6 +68,9 @@ private:
   /// read all the controller settings from the parameter server
   void read_parameters();
 
+  /// clamp the command to velocity limits
+  double clamp_command(double cmd);
+
   /// set the velocity target from a topic
   void setCommandCB(const std_msgs::Float64ConstPtr &msg);
 

--- a/sr_mechanism_controllers/src/sr_controller.cpp
+++ b/sr_mechanism_controllers/src/sr_controller.cpp
@@ -44,6 +44,10 @@ namespace controller
             command_(0),
             min_(0.0),
             max_(sr_math_utils::pi),
+            vel_min_(-1 * sr_math_utils::pi),
+            vel_max_(sr_math_utils::pi),
+            eff_min_(-1023.),
+            eff_max_(1023.),
             loop_count_(0),
             initialized_(false),
             robot_(NULL),
@@ -108,6 +112,10 @@ namespace controller
 
       min_ = joint1->limits->lower + joint2->limits->lower;
       max_ = joint1->limits->upper + joint2->limits->upper;
+      vel_max_ = joint1->limits->velocity + joint2->limits->velocity;
+      vel_min_ = -1 * vel_max_;
+      eff_max_ = joint1->limits->effort + joint2->limits->effort;
+      eff_min_ = -1 * eff_max_;
     }
     else
     {
@@ -115,22 +123,29 @@ namespace controller
 
       min_ = joint->limits->lower;
       max_ = joint->limits->upper;
+      vel_max_ = joint->limits->velocity;
+      vel_min_ = -1 * vel_max_;
+      eff_max_ = joint->limits->effort;
+      eff_min_ = -1 * eff_max_;
     }
+  }
+
+  double SrController::clamp_command(double cmd, double min_cmd, double max_cmd)
+  {
+    if (cmd < min_cmd)
+    {
+      return min_cmd;
+    }
+    if (cmd > max_cmd)
+    {
+      return max_cmd;
+    }
+    return cmd;
   }
 
   double SrController::clamp_command(double cmd)
   {
-    if (cmd < min_)
-    {
-      return min_;
-    }
-
-    if (cmd > max_)
-    {
-      return max_;
-    }
-
-    return cmd;
+    return clamp_command(cmd, min_, max_);
   }
 
   void SrController::maxForceFactorCB(const std_msgs::Float64ConstPtr &msg)

--- a/sr_mechanism_controllers/src/srh_joint_effort_controller.cpp
+++ b/sr_mechanism_controllers/src/srh_joint_effort_controller.cpp
@@ -104,6 +104,9 @@ namespace controller
 
     friction_compensator.reset(new sr_friction_compensation::SrFrictionCompensator(joint_name_));
 
+    // get the min and max value for the current joint:
+    get_min_max(robot_->robot_model_, joint_name_);
+
     serve_set_gains_ = node_.advertiseService("set_gains", &SrhEffortJointController::setGains, this);
     serve_reset_gains_ = node_.advertiseService("reset_gains", &SrhEffortJointController::resetGains, this);
 
@@ -172,7 +175,7 @@ namespace controller
     // The commanded effort is the error directly:
     // the PID loop for the force controller is running on the
     // motorboard.
-    double commanded_effort = command_;
+    double commanded_effort = command_;  // clamp_command(command_) // do not use urdf effort limits;
 
     // Clamps the effort
     commanded_effort = min(commanded_effort, (max_force_demand * max_force_factor_));
@@ -217,6 +220,11 @@ namespace controller
       }
     }
     loop_count_++;
+  }
+
+  double SrhEffortJointController::clamp_command(double cmd)
+  {
+    return SrController::clamp_command(cmd, eff_min_, eff_max_);
   }
 
   void SrhEffortJointController::read_parameters()

--- a/sr_mechanism_controllers/src/srh_joint_velocity_controller.cpp
+++ b/sr_mechanism_controllers/src/srh_joint_velocity_controller.cpp
@@ -128,6 +128,9 @@ namespace controller
 
     friction_compensator.reset(new sr_friction_compensation::SrFrictionCompensator(joint_name_));
 
+    // get the min and max value for the current joint:
+    get_min_max(robot_->robot_model_, joint_name_);
+
     serve_set_gains_ = node_.advertiseService("set_gains", &SrhJointVelocityController::setGains, this);
     serve_reset_gains_ = node_.advertiseService("reset_gains", &SrhJointVelocityController::resetGains, this);
 
@@ -288,6 +291,11 @@ namespace controller
       }
     }
     loop_count_++;
+  }
+
+  double SrhJointVelocityController::clamp_command(double cmd)
+  {
+    return SrController::clamp_command(cmd, vel_min_, vel_max_);
   }
 
   void SrhJointVelocityController::read_parameters()


### PR DESCRIPTION
_sr_controller_ now extracts and stores all the limits (angle, velocities, effort)
_sr_controller_ provides a generic clamp function with a default implementation for angle (backward compatibility)
velocity and effort controllers re-implement their own clamp using vel or eff min/max

solves #69 

EffortController had remains with no clamp applied to the input because the effort range is not calibrated (commands are in gauge units currently so do not match URDF values in newtonmeter)
