### PR TITLE
Specific boost includes

### DIFF
--- a/sr_hand/include/sr_hand/hand/sr_articulated_robot.h
+++ b/sr_hand/include/sr_hand/hand/sr_articulated_robot.h
@@ -41,7 +41,7 @@
 #include "self_test/self_test.h"
 
 #include <boost/smart_ptr.hpp>
-#include <boost/thread.hpp>
+#include <boost/thread/mutex.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/assign.hpp>
 

--- a/sr_hand/src/hand/CAN_compatibility_arm_node.cpp
+++ b/sr_hand/src/hand/CAN_compatibility_arm_node.cpp
@@ -29,7 +29,7 @@
 
 #include <ros/ros.h>
 
-#include <boost/thread.hpp>
+#include <boost/thread/thread.hpp>
 #include <boost/smart_ptr.hpp>
 
 #include "sr_hand/sr_subscriber.h"

--- a/sr_hand/src/hand/etherCAT_compatibility_hand_node.cpp
+++ b/sr_hand/src/hand/etherCAT_compatibility_hand_node.cpp
@@ -29,7 +29,7 @@
 
 #include <ros/ros.h>
 
-#include <boost/thread.hpp>
+#include <boost/thread/thread.hpp>
 #include <boost/smart_ptr.hpp>
 
 #include "sr_hand/sr_subscriber.h"

--- a/sr_hand/src/hand/real_arm_node.cpp
+++ b/sr_hand/src/hand/real_arm_node.cpp
@@ -29,7 +29,7 @@
 
 #include <ros/ros.h>
 
-#include <boost/thread.hpp>
+#include <boost/thread/thread.hpp>
 #include <boost/smart_ptr.hpp>
 
 #include "sr_hand/sr_subscriber.h"

--- a/sr_hand/src/hand/real_shadowhand_node.cpp
+++ b/sr_hand/src/hand/real_shadowhand_node.cpp
@@ -29,7 +29,7 @@
 
 #include <ros/ros.h>
 
-#include <boost/thread.hpp>
+#include <boost/thread/thread.hpp>
 #include <boost/smart_ptr.hpp>
 
 #include "sr_hand/sr_subscriber.h"

--- a/sr_hand/src/hand/virtual_arm_node.cpp
+++ b/sr_hand/src/hand/virtual_arm_node.cpp
@@ -29,7 +29,7 @@
 
 #include <ros/ros.h>
 
-#include <boost/thread.hpp>
+#include <boost/thread/thread.hpp>
 #include <boost/smart_ptr.hpp>
 
 #include "sr_hand/sr_subscriber.h"

--- a/sr_hand/src/hand/virtual_shadowhand_node.cpp
+++ b/sr_hand/src/hand/virtual_shadowhand_node.cpp
@@ -29,7 +29,7 @@
 
 #include <ros/ros.h>
 
-#include <boost/thread.hpp>
+#include <boost/thread/thread.hpp>
 #include <boost/smart_ptr.hpp>
 
 #include "sr_hand/sr_subscriber.h"

--- a/sr_self_test/include/sr_self_test/sr_self_test.hpp
+++ b/sr_self_test/include/sr_self_test/sr_self_test.hpp
@@ -36,7 +36,7 @@
 #include "sr_self_test/sr_test_runner.hpp"
 #include "sr_self_test/motor_test.hpp"
 
-#include <boost/thread.hpp>
+#include <boost/thread/thread.hpp>
 #include <boost/ptr_container/ptr_vector.hpp>
 #include <sr_robot_msgs/joint.h>
 #include <sr_hand/hand_commander.hpp>

--- a/sr_self_test/include/sr_self_test/test_joint_movement.hpp
+++ b/sr_self_test/include/sr_self_test/test_joint_movement.hpp
@@ -30,6 +30,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <boost/thread/thread.hpp>
 #include <sr_movements/movement_from_image.hpp>
 #include <sr_movements/movement_publisher.hpp>
 #include <sr_robot_msgs/JointControllerState.h>

--- a/sr_tactile_sensors/examples/tactile.cpp
+++ b/sr_tactile_sensors/examples/tactile.cpp
@@ -29,7 +29,7 @@
 #include <ros/ros.h>
 #include <string>
 
-#include <boost/thread.hpp>
+#include <boost/thread/mutex.hpp>
 
 // messages
 #include <std_msgs/Float64.h>

--- a/sr_tactile_sensors/include/sr_tactile_sensors/sr_gazebo_virtual_tactile_sensor.hpp
+++ b/sr_tactile_sensors/include/sr_tactile_sensors/sr_gazebo_virtual_tactile_sensor.hpp
@@ -31,7 +31,7 @@
 
 #include <ros/ros.h>
 
-#include <boost/thread.hpp>
+#include <boost/thread/mutex.hpp>
 #include <string>
 
 #include "sr_tactile_sensors/sr_generic_tactile_sensor.hpp"

--- a/sr_tactile_sensors/include/sr_tactile_sensors/sr_virtual_tactile_sensor.hpp
+++ b/sr_tactile_sensors/include/sr_tactile_sensors/sr_virtual_tactile_sensor.hpp
@@ -31,7 +31,7 @@
 
 #include <ros/ros.h>
 
-#include <boost/thread.hpp>
+#include <boost/thread/mutex.hpp>
 #include <string>
 #include <vector>
 

--- a/sr_tactile_sensors/src/sr_bumper_rviz_marker.cpp
+++ b/sr_tactile_sensors/src/sr_bumper_rviz_marker.cpp
@@ -30,7 +30,7 @@
 #include <string>
 #include <vector>
 
-#include <boost/thread.hpp>
+#include <boost/thread/mutex.hpp>
 
 #include <std_msgs/Float64.h>
 

--- a/sr_tactile_sensors/src/sr_tactile_rviz_marker.cpp
+++ b/sr_tactile_sensors/src/sr_tactile_rviz_marker.cpp
@@ -25,7 +25,7 @@
 
 #include <ros/ros.h>
 #include <string>
-#include <boost/thread.hpp>
+#include <boost/thread/mutex.hpp>
 
 // messages
 #include <std_msgs/Float64.h>

--- a/sr_utilities/include/sr_utilities/thread_safe_map.hpp
+++ b/sr_utilities/include/sr_utilities/thread_safe_map.hpp
@@ -29,7 +29,8 @@
 #define _THREAD_SAFE_MAP_HPP_
 
 #include <boost/smart_ptr.hpp>
-#include <boost/thread.hpp>
+#include <boost/thread/shared_mutex.hpp>
+#include <boost/thread/mutex.hpp>
 
 #include <map>
 #include <vector>


### PR DESCRIPTION
A bug in boost 1.58 in future.hpp prevents from building on xenial. 
This PR  just provides specific includes instead of the generic one for thread.hpp, and does not change functionality

Since the change does not affect indigo-devel, I suggest to merge it there.
Main loop and driver changes were tested on our system on indigo. Changes on sr_hand stuff were not tested.
