### PR TITLE
Add support for antiwindup in the gain setter (was losing the setting)

### DIFF
--- a/sr_mechanism_controllers/src/srh_mixed_position_velocity_controller.cpp
+++ b/sr_mechanism_controllers/src/srh_mixed_position_velocity_controller.cpp
@@ -190,7 +190,7 @@ namespace controller
             req.velocity_d << ", " << req.velocity_i_clamp << "], max force: " << req.max_force <<
             ", friction deadband: " << req.friction_deadband << " pos deadband: " << req.position_deadband <<
             " min and max vel: [" << req.min_velocity << ", " << req.max_velocity << "]");
-            
+
     // retrieve previous antiwindup settings for velocity
     double p, i, d, i_max, i_min;
     bool antiwindup;

--- a/sr_mechanism_controllers/src/srh_mixed_position_velocity_controller.cpp
+++ b/sr_mechanism_controllers/src/srh_mixed_position_velocity_controller.cpp
@@ -190,12 +190,17 @@ namespace controller
             req.velocity_d << ", " << req.velocity_i_clamp << "], max force: " << req.max_force <<
             ", friction deadband: " << req.friction_deadband << " pos deadband: " << req.position_deadband <<
             " min and max vel: [" << req.min_velocity << ", " << req.max_velocity << "]");
+            
+    // retrieve previous antiwindup settings for velocity
+    double p, i, d, i_max, i_min;
+    bool antiwindup;
+    pid_controller_velocity_->getGains(p, i, d, i_max, i_min, antiwindup);
 
     pid_controller_position_->setGains(req.position_p, req.position_i, req.position_d, req.position_i_clamp,
                                        -req.position_i_clamp);
 
     pid_controller_velocity_->setGains(req.velocity_p, req.velocity_i, req.velocity_d, req.velocity_i_clamp,
-                                       -req.velocity_i_clamp);
+                                       -req.velocity_i_clamp, antiwindup);
     max_force_demand = req.max_force;
     friction_deadband = req.friction_deadband;
     position_deadband = req.position_deadband;
@@ -221,6 +226,7 @@ namespace controller
 
     node_.setParam("velocity_pid/friction_deadband", friction_deadband);
     node_.setParam("velocity_pid/max_force", max_force_demand);
+    node_.setParam("velocity_pid/antiwindup", antiwindup);
     node_.setParam("motor_min_force_threshold", motor_min_force_threshold);
 
     return true;


### PR DESCRIPTION
control_toolbox in kinetic includes antiwindup support. This patch permits to not lose the value of the antiwindup if set