### PR TITLE
checking if increasing timeout makes jenkins pass

### DIFF
--- a/sr_hand/test/hand_commander_test.test
+++ b/sr_hand/test/hand_commander_test.test
@@ -3,5 +3,5 @@
     <arg name="gui" value="false"/>
   </include>
 
-  <test test-name="hand_commander_test" pkg="sr_hand" type="hand_commander_test" time-limit="360.00"/>
+  <test test-name="hand_commander_test" pkg="sr_hand" type="hand_commander_test" time-limit="720.00"/>
 </launch>


### PR DESCRIPTION
tests took a lot of time on the container but passed, maybe need more time on one of jenkins slaves, increasing timeout