### PR TITLE
use boost/std-agnostic shared_ptrs for urdf types

### DIFF
--- a/sr_gazebo_sim/src/gazebo_hardware_sim.cpp
+++ b/sr_gazebo_sim/src/gazebo_hardware_sim.cpp
@@ -125,7 +125,7 @@ namespace sr_gazebo_sim
   {
     this->fake_state_.robot_model_ = *urdf_model;
 
-    for (std::map<std::string, boost::shared_ptr<urdf::Joint> >::const_iterator it = urdf_model->joints_.begin();
+    for (std::map<std::string, urdf::JointSharedPtr>::const_iterator it = urdf_model->joints_.begin();
          it != urdf_model->joints_.end(); ++it)
     {
       if (this->isHandJoint(transmissions, it->first))

--- a/sr_hand/include/sr_hand/hand_commander.hpp
+++ b/sr_hand/include/sr_hand/hand_commander.hpp
@@ -101,7 +101,7 @@ private:
   NodeHandle node_;
 
   /// stores data about the hand (read from urdf)
-  std::map<std::string, boost::shared_ptr<urdf::Joint> > all_joints;
+  std::map<std::string, urdf::JointSharedPtr> all_joints;
 
   /// Publisher for the CAN hand targets
   Publisher sr_hand_target_pub;

--- a/sr_hand/src/hand/virtual_shadowhand.cpp
+++ b/sr_hand/src/hand/virtual_shadowhand.cpp
@@ -97,8 +97,8 @@ namespace shadowrobot
       return;
     }
 
-    std::map<std::string, boost::shared_ptr<urdf::Joint> > all_joints = robot_model.joints_;
-    std::map<std::string, boost::shared_ptr<urdf::Joint> >::const_iterator iter = all_joints.begin();
+    std::map<std::string, urdf::JointSharedPtr> all_joints = robot_model.joints_;
+    std::map<std::string, urdf::JointSharedPtr>::const_iterator iter = all_joints.begin();
     ROS_DEBUG("All the Hand joints: ");
 
 #ifdef GAZEBO

--- a/sr_hand/src/hand_commander.cpp
+++ b/sr_hand/src/hand_commander.cpp
@@ -173,7 +173,7 @@ namespace shadowrobot
     {
       std::string jn = joint_names[i];
 
-      std::map<std::string, boost::shared_ptr<urdf::Joint> >::iterator it = all_joints.find(jn);
+      std::map<std::string, urdf::JointSharedPtr>::iterator it = all_joints.find(jn);
 
       if (it != all_joints.end())
       {

--- a/sr_mechanism_controllers/src/sr_controller.cpp
+++ b/sr_mechanism_controllers/src/sr_controller.cpp
@@ -107,8 +107,8 @@ namespace controller
       joint_name[joint_name.size() - 1] = '2';
       std::string j2 = joint_name;
 
-      boost::shared_ptr<const urdf::Joint> joint1 = model.getJoint(j1);
-      boost::shared_ptr<const urdf::Joint> joint2 = model.getJoint(j2);
+      urdf::JointConstSharedPtr joint1 = model.getJoint(j1);
+      urdf::JointConstSharedPtr joint2 = model.getJoint(j2);
 
       min_ = joint1->limits->lower + joint2->limits->lower;
       max_ = joint1->limits->upper + joint2->limits->upper;
@@ -119,7 +119,7 @@ namespace controller
     }
     else
     {
-      boost::shared_ptr<const urdf::Joint> joint = model.getJoint(joint_name);
+      urdf::JointConstSharedPtr joint = model.getJoint(joint_name);
 
       min_ = joint->limits->lower;
       max_ = joint->limits->upper;

--- a/sr_utilities/src/sr_arm_finder.cpp
+++ b/sr_utilities/src/sr_arm_finder.cpp
@@ -32,9 +32,6 @@
 #include <vector>
 #include <string>
 
-using urdf::ModelInterface;
-using urdf::Joint;
-
 namespace shadow_robot
 {
 SrArmFinder::SrArmFinder()
@@ -51,13 +48,13 @@ SrArmFinder::SrArmFinder()
                                                       default_hand_joints_vector.end());
       std::string robot_description;
       ros::param::get("robot_description", robot_description);
-      const boost::shared_ptr<ModelInterface> hand_urdf = urdf::parseURDF(robot_description);
+      const urdf::ModelInterfaceSharedPtr hand_urdf = urdf::parseURDF(robot_description);
 
-      std::pair<std::string, boost::shared_ptr<Joint> > joint;
+      std::pair<std::string, urdf::JointSharedPtr> joint;
       BOOST_FOREACH(joint, hand_urdf->joints_)
       {
         const std::string joint_name = joint.first;
-        if ((Joint::FIXED != joint.second->type) && (hand_default_joints.end() == hand_default_joints.find(joint_name)))
+        if ((urdf::Joint::FIXED != joint.second->type) && (hand_default_joints.end() == hand_default_joints.find(joint_name)))
         {
           bool found_suffix = false;
           BOOST_FOREACH(std::string default_joint_name, hand_default_joints)

--- a/sr_utilities/src/sr_hand_finder.cpp
+++ b/sr_utilities/src/sr_hand_finder.cpp
@@ -36,8 +36,6 @@
 #include <iostream>
 
 using boost::assign::list_of;
-using urdf::ModelInterface;
-using urdf::Joint;
 
 namespace shadow_robot
 {
@@ -103,14 +101,14 @@ void SrHandFinder::generate_joints_with_prefix()
     }
     std::string robot_description;
     ros::param::get("robot_description", robot_description);
-    const boost::shared_ptr<ModelInterface> hand_urdf = urdf::parseURDF(robot_description);
+    const urdf::ModelInterfaceSharedPtr hand_urdf = urdf::parseURDF(robot_description);
     BOOST_FOREACH(hand, hand_config_.joint_prefix_)
     {
       std::set<std::string> joints_tmp;
-      std::pair<std::string, boost::shared_ptr<Joint> > joint;
+      std::pair<std::string, urdf::JointSharedPtr> joint;
       BOOST_FOREACH(joint, hand_urdf->joints_)
       {
-        if (Joint::FIXED != joint.second->type)
+        if (urdf::Joint::FIXED != joint.second->type)
         {
           const std::string joint_name = joint.first;
           bool found_prefix = false;


### PR DESCRIPTION
needed for bionic build, and is backward compatible with kinetic (since it is boost/std-agnostic)