### PR TITLE
Switched to tinyxml2

### DIFF
--- a/sr_gazebo_sim/CMakeLists.txt
+++ b/sr_gazebo_sim/CMakeLists.txt
@@ -2,15 +2,15 @@ cmake_minimum_required(VERSION 2.8.12)
 project(sr_gazebo_sim)
 
 find_package(catkin REQUIRED COMPONENTS roscpp sr_hardware_interface cmake_modules ros_ethercat_model gazebo_ros_control)
-find_package(TinyXML REQUIRED)
+find_package(TinyXML2 REQUIRED)
 find_package(gazebo REQUIRED)
 
-include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS} ${TinyXML_INCLUDE_DIRS} ${GAZEBO_INCLUDE_DIRS} ${SDFormat_INCLUDE_DIRS})
+include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS} ${TinyXML2_INCLUDE_DIRS} ${GAZEBO_INCLUDE_DIRS} ${SDFormat_INCLUDE_DIRS})
 
 add_compile_options(${GAZEBO_CXX_FLAGS})
 
 catkin_package(
-        DEPENDS TinyXML
+        DEPENDS tinyxml2
         CATKIN_DEPENDS roscpp sr_hardware_interface ros_ethercat_model gazebo_ros_control
         INCLUDE_DIRS include
         LIBRARIES sr_gazebo_sim
@@ -18,7 +18,7 @@ catkin_package(
 
 add_library(sr_gazebo_sim src/gazebo_hardware_sim.cpp)
 add_dependencies(sr_gazebo_sim ${catkin_EXPORTED_TARGETS})
-target_link_libraries(sr_gazebo_sim ${TinyXML_LIBRARIES} ${catkin_LIBRARIES})
+target_link_libraries(sr_gazebo_sim ${TinyXML2_LIBRARIES} ${catkin_LIBRARIES})
 
 install(TARGETS sr_gazebo_sim
         LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/sr_gazebo_sim/package.xml
+++ b/sr_gazebo_sim/package.xml
@@ -19,7 +19,7 @@
     <build_depend>roscpp</build_depend>
     <build_depend>sr_hardware_interface</build_depend>
     <build_depend>cmake_modules</build_depend>
-    <build_depend>tinyxml</build_depend>
+    <build_depend>tinyxml2</build_depend>
     <build_depend>ros_ethercat_model</build_depend>
     <build_depend>gazebo_ros_control</build_depend>
     <build_depend>gazebo</build_depend>
@@ -27,7 +27,7 @@
     <!-- Dependencies needed after this package is compiled. -->
     <run_depend>roscpp</run_depend>
     <run_depend>sr_hardware_interface</run_depend>
-    <run_depend>tinyxml</run_depend>
+    <run_depend>tinyxml2</run_depend>
     <run_depend>ros_ethercat_model</run_depend>
     <run_depend>gazebo_ros_control</run_depend>
     <run_depend>gazebo</run_depend>

--- a/sr_gazebo_sim/src/gazebo_hardware_sim.cpp
+++ b/sr_gazebo_sim/src/gazebo_hardware_sim.cpp
@@ -35,7 +35,7 @@ namespace sr_gazebo_sim
   const std::string SrGazeboHWSim::simple_transmission_name = "sr_mechanism_model/SimpleTransmission";
 
   SrGazeboHWSim::SrGazeboHWSim() :
-          DefaultRobotHWSim(), fake_state_(NULL)
+          DefaultRobotHWSim(), fake_state_((tinyxml2::XMLElement *)NULL)
   {
   }
 

--- a/sr_mechanism_controllers/CMakeLists.txt
+++ b/sr_mechanism_controllers/CMakeLists.txt
@@ -3,8 +3,8 @@ project(sr_mechanism_controllers)
 find_package(catkin REQUIRED COMPONENTS rostest std_msgs std_srvs roscpp actionlib controller_manager_msgs sr_robot_msgs
         sr_utilities controller_interface ros_ethercat_model realtime_tools velocity_controllers
         pluginlib rosconsole angles control_toolbox sr_hardware_interface xmlrpcpp cmake_modules)
-find_package(TinyXML REQUIRED)
-include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS} ${TinyXML_INCLUDE_DIRS})
+find_package(TinyXML2 REQUIRED)
+include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS} ${TinyXML2_INCLUDE_DIRS})
 
 catkin_package(
         DEPENDS xmlrpcpp
@@ -66,12 +66,12 @@ target_link_libraries(simple_trajectory_compare ${catkin_LIBRARIES})
 #  add_rostest_gtest(test_joint_pos_controller test/joint_pos_controller.test test/test_joint_pos_controller.cpp test/test_controllers.cpp
 #    src/srh_joint_position_controller.cpp src/sr_controller.cpp)
 #  add_dependencies(test_joint_pos_controller ${catkin_EXPORTED_TARGETS})
-#  target_link_libraries(test_joint_pos_controller sr_mechanism_controllers ${GTEST_LIBRARIES} ${catkin_LIBRARIES} ${TinyXML_LIBRARIES})
+#  target_link_libraries(test_joint_pos_controller sr_mechanism_controllers ${GTEST_LIBRARIES} ${catkin_LIBRARIES} ${TinyXML2_LIBRARIES})
 
 #  add_rostest_gtest(test_joint_pos_controller_with_fc test/joint_pos_controller_with_fc.test test/test_joint_pos_controller.cpp test/test_controllers.cpp
 #    src/srh_joint_position_controller.cpp src/sr_controller.cpp)
 #  add_dependencies(test_joint_pos_controller_with_fc ${catkin_EXPORTED_TARGETS})
-#  target_link_libraries(test_joint_pos_controller_with_fc sr_mechanism_controllers ${GTEST_LIBRARIES} ${catkin_LIBRARIES} ${TinyXML_LIBRARIES})
+#  target_link_libraries(test_joint_pos_controller_with_fc sr_mechanism_controllers ${GTEST_LIBRARIES} ${catkin_LIBRARIES} ${TinyXML2_LIBRARIES})
 #endif(COMMAND add_rostest_gtest)
 
 install(TARGETS joint_trajectory_action_controller joint_spline_trajectory_action_controller simple_spline_trajectory

--- a/sr_mechanism_controllers/include/sr_mechanism_controllers/test/test_controllers.hpp
+++ b/sr_mechanism_controllers/include/sr_mechanism_controllers/test/test_controllers.hpp
@@ -33,7 +33,7 @@
 #include <control_toolbox/pid.h>
 #include <pr2_hardware_interface/hardware_interface.h>
 #include <pr2_mechanism_model/robot.h>
-#include <tinyxml.h>
+#include <tinyxml2.h>
 #include <sr_hardware_interface/sr_actuator.hpp>
 
 class TestControllers
@@ -53,7 +53,7 @@ public:
   boost::shared_ptr <pr2_hardware_interface::HardwareInterface> hw;
   boost::shared_ptr <pr2_mechanism_model::Robot> robot;
   boost::shared_ptr <pr2_mechanism_model::RobotState> robot_state;
-  boost::shared_ptr <TiXmlDocument> model;
+  boost::shared_ptr <tinyxml2::XMLDocument> model;
   boost::shared_ptr <sr_actuator::SrMotorActuator> actuator;
   pr2_mechanism_model::JointState *joint_state;
 };

--- a/sr_mechanism_controllers/package.xml
+++ b/sr_mechanism_controllers/package.xml
@@ -38,7 +38,7 @@
     <build_depend>xmlrpcpp</build_depend>
     <build_depend>rostest</build_depend>
     <build_depend>cmake_modules</build_depend>
-    <build_depend>tinyxml</build_depend>
+    <build_depend>tinyxml2</build_depend>
     <build_depend>ros_ethercat_model</build_depend>
 
     <!-- Dependencies needed after this package is compiled. -->

--- a/sr_mechanism_controllers/test/test_controllers.cpp
+++ b/sr_mechanism_controllers/test/test_controllers.cpp
@@ -45,7 +45,7 @@ void TestControllers::init()
 
   robot = boost::shared_ptr<pr2_mechanism_model::Robot>(new pr2_mechanism_model::Robot(hw.get()));
 
-  model = boost::shared_ptr<TiXmlDocument>(new TiXmlDocument());
+  model = boost::shared_ptr<tinyxml2::XMLDocument>(new tinyxml2::XMLDocument());
 
   ros::NodeHandle rosnode;
   std::string urdf_param_name;
@@ -70,7 +70,7 @@ void TestControllers::init()
   }
   ROS_DEBUG("Parsing xml...");
 
-  // initialize TiXmlDocument doc with a string
+  // initialize tinyxml2::XMLDocument doc with a string
   if (!model->Parse(urdf_string.c_str()) && model->Error())
   {
     ROS_ERROR("Failed to parse urdf: %s\n",

--- a/sr_mechanism_model/CMakeLists.txt
+++ b/sr_mechanism_model/CMakeLists.txt
@@ -1,11 +1,11 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(sr_mechanism_model)
 find_package(catkin REQUIRED COMPONENTS roscpp sr_hardware_interface cmake_modules ros_ethercat_model)
-find_package(TinyXML REQUIRED)
-include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS} ${TinyXML_INCLUDE_DIRS})
+find_package(TinyXML2 REQUIRED)
+include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS} ${TinyXML2_INCLUDE_DIRS})
 
 catkin_package(
-        DEPENDS TinyXML
+        DEPENDS TinyXML2
         CATKIN_DEPENDS roscpp sr_hardware_interface ros_ethercat_model
         INCLUDE_DIRS include
         LIBRARIES sr_mechanism_model
@@ -14,7 +14,7 @@ catkin_package(
 add_library(sr_mechanism_model src/joint_0_transmission.cpp src/simple_transmission.cpp
         src/joint_0_transmission_for_muscle.cpp src/simple_transmission_for_muscle.cpp src/null_transmission.cpp)
 add_dependencies(sr_mechanism_model ${catkin_EXPORTED_TARGETS})
-target_link_libraries(sr_mechanism_model ${TinyXML_LIBRARIES} ${catkin_LIBRARIES})
+target_link_libraries(sr_mechanism_model ${TinyXML2_LIBRARIES} ${catkin_LIBRARIES})
 
 install(TARGETS sr_mechanism_model
         LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/sr_mechanism_model/include/sr_mechanism_model/joint_0_transmission.hpp
+++ b/sr_mechanism_model/include/sr_mechanism_model/joint_0_transmission.hpp
@@ -37,7 +37,7 @@ class J0Transmission :
         public SimpleTransmission
 {
 public:
-  bool initXml(TiXmlElement *config, ros_ethercat_model::RobotState *robot);
+  bool initXml(tinyxml2::XMLElement *config, ros_ethercat_model::RobotState *robot);
 
   void propagatePosition();
 

--- a/sr_mechanism_model/include/sr_mechanism_model/joint_0_transmission_for_muscle.hpp
+++ b/sr_mechanism_model/include/sr_mechanism_model/joint_0_transmission_for_muscle.hpp
@@ -36,7 +36,7 @@ class J0TransmissionForMuscle :
         public SimpleTransmissionForMuscle
 {
 public:
-  bool initXml(TiXmlElement *config, ros_ethercat_model::RobotState *robot);
+  bool initXml(tinyxml2::XMLElement *config, ros_ethercat_model::RobotState *robot);
 
   void propagatePosition();
 

--- a/sr_mechanism_model/include/sr_mechanism_model/null_transmission.hpp
+++ b/sr_mechanism_model/include/sr_mechanism_model/null_transmission.hpp
@@ -52,7 +52,7 @@ class NullTransmission :
         public ros_ethercat_model::Transmission
 {
 public:
-  bool initXml(TiXmlElement *config, ros_ethercat_model::RobotState *robot);
+  bool initXml(tinyxml2::XMLElement *config, ros_ethercat_model::RobotState *robot);
 
   void propagatePosition();
 

--- a/sr_mechanism_model/include/sr_mechanism_model/simple_transmission.hpp
+++ b/sr_mechanism_model/include/sr_mechanism_model/simple_transmission.hpp
@@ -57,7 +57,7 @@ public:
     ROS_DEBUG_STREAM("Destroying simple transmission");
   }  // added degub stream line because empty destructor make sr-ros-interface-interface unit test fail
 
-  bool initXml(TiXmlElement *config, ros_ethercat_model::RobotState *robot);
+  bool initXml(tinyxml2::XMLElement *config, ros_ethercat_model::RobotState *robot);
 
   void propagatePosition();
 

--- a/sr_mechanism_model/include/sr_mechanism_model/simple_transmission_for_muscle.hpp
+++ b/sr_mechanism_model/include/sr_mechanism_model/simple_transmission_for_muscle.hpp
@@ -47,7 +47,7 @@ class SimpleTransmissionForMuscle :
         public sr_mechanism_model::SimpleTransmission
 {
 public:
-  bool initXml(TiXmlElement *config, ros_ethercat_model::RobotState *robot);
+  bool initXml(tinyxml2::XMLElement *config, ros_ethercat_model::RobotState *robot);
 
   void propagatePosition();
 

--- a/sr_mechanism_model/src/joint_0_transmission.cpp
+++ b/sr_mechanism_model/src/joint_0_transmission.cpp
@@ -40,7 +40,7 @@ PLUGINLIB_EXPORT_CLASS(sr_mechanism_model::J0Transmission, Transmission)
 namespace sr_mechanism_model
 {
 
-  bool J0Transmission::initXml(TiXmlElement *elt, RobotState *robot)
+  bool J0Transmission::initXml(tinyxml2::XMLElement *elt, RobotState *robot)
   {
     if (!SimpleTransmission::initXml(elt, robot))
     {

--- a/sr_mechanism_model/src/joint_0_transmission_for_muscle.cpp
+++ b/sr_mechanism_model/src/joint_0_transmission_for_muscle.cpp
@@ -38,7 +38,7 @@ PLUGINLIB_EXPORT_CLASS(sr_mechanism_model::J0TransmissionForMuscle, Transmission
 namespace sr_mechanism_model
 {
 
-  bool J0TransmissionForMuscle::initXml(TiXmlElement *elt, RobotState *robot)
+  bool J0TransmissionForMuscle::initXml(tinyxml2::XMLElement *elt, RobotState *robot)
   {
     if (!SimpleTransmissionForMuscle::initXml(elt, robot))
     {

--- a/sr_mechanism_model/src/null_transmission.cpp
+++ b/sr_mechanism_model/src/null_transmission.cpp
@@ -49,7 +49,7 @@ PLUGINLIB_EXPORT_CLASS(sr_mechanism_model::NullTransmission, Transmission)
 namespace sr_mechanism_model
 {
 
-  bool NullTransmission::initXml(TiXmlElement *elt, RobotState *robot)
+  bool NullTransmission::initXml(tinyxml2::XMLElement *elt, RobotState *robot)
   {
     if (!Transmission::initXml(elt, robot))
     {
@@ -57,14 +57,14 @@ namespace sr_mechanism_model
     }
 
     // reading the joint name
-    TiXmlElement *jel = elt->FirstChildElement("joint");
+    tinyxml2::XMLElement *jel = elt->FirstChildElement("joint");
     if (!jel || !jel->Attribute("name"))
     {
       ROS_ERROR_STREAM("Joint name not specified in transmission " << name_);
       return false;
     }
 
-    TiXmlElement *ael = elt->FirstChildElement("actuator");
+    tinyxml2::XMLElement *ael = elt->FirstChildElement("actuator");
     if (!ael || !ael->Attribute("name"))
     {
       ROS_ERROR_STREAM("Transmission " << name_ << " has no actuator in configuration");

--- a/sr_mechanism_model/src/simple_transmission.cpp
+++ b/sr_mechanism_model/src/simple_transmission.cpp
@@ -48,7 +48,7 @@ PLUGINLIB_EXPORT_CLASS(sr_mechanism_model::SimpleTransmission, Transmission)
 namespace sr_mechanism_model
 {
 
-  bool SimpleTransmission::initXml(TiXmlElement *elt, RobotState *robot)
+  bool SimpleTransmission::initXml(tinyxml2::XMLElement *elt, RobotState *robot)
   {
     if (!ros_ethercat_model::Transmission::initXml(elt, robot))
     {
@@ -56,14 +56,14 @@ namespace sr_mechanism_model
     }
 
     // reading the joint name
-    TiXmlElement *jel = elt->FirstChildElement("joint");
+    tinyxml2::XMLElement *jel = elt->FirstChildElement("joint");
     if (!jel || !jel->Attribute("name"))
     {
       ROS_ERROR_STREAM("Joint name not specified in transmission " << name_);
       return false;
     }
 
-    TiXmlElement *ael = elt->FirstChildElement("actuator");
+    tinyxml2::XMLElement *ael = elt->FirstChildElement("actuator");
     if (!ael || !ael->Attribute("name"))
     {
       ROS_ERROR_STREAM("Transmission " << name_ << " has no actuator in configuration");

--- a/sr_mechanism_model/src/simple_transmission_for_muscle.cpp
+++ b/sr_mechanism_model/src/simple_transmission_for_muscle.cpp
@@ -50,7 +50,7 @@ PLUGINLIB_EXPORT_CLASS(sr_mechanism_model::SimpleTransmissionForMuscle, Transmis
 namespace sr_mechanism_model
 {
 
-  bool SimpleTransmissionForMuscle::initXml(TiXmlElement *elt, RobotState *robot)
+  bool SimpleTransmissionForMuscle::initXml(tinyxml2::XMLElement *elt, RobotState *robot)
   {
     if (!SimpleTransmission::Transmission::initXml(elt, robot))
     {


### PR DESCRIPTION
switched to tinyxml2 (removed deprecated warning in bionic), not backward compatible to kinetic
Other similar PR should be merged at the same time to fully upgrade to tinyxml2