### PR TITLE
F #src 3815 biotac pac

### DIFF
--- a/sr_hardware_interface/include/sr_hardware_interface/tactile_sensors.hpp
+++ b/sr_hardware_interface/include/sr_hardware_interface/tactile_sensors.hpp
@@ -296,8 +296,8 @@ public:
   int tac;  // int16u in word[2]
   int tdc;  // int16u in word[2]
   std::vector<int16_t> electrodes;  // int16u in word[2]
-  boost::circular_buffer<int16_t> pac_buffer_;  // 2.2kHz history of int16u/word[2] values. Capacity of 270 samples is
-                                                // 10 read cycles, or 122ms history
+  boost::circular_buffer<int16_t> pac_buffer_;  // 2kHz history of int16u/word[2] values. Capacity of 270 samples is
+                                                // 135ms history
   static const size_t pac_size_ = 270;
 
 private:

--- a/sr_hardware_interface/include/sr_hardware_interface/tactile_sensors.hpp
+++ b/sr_hardware_interface/include/sr_hardware_interface/tactile_sensors.hpp
@@ -296,12 +296,12 @@ public:
   int tac;  // int16u in word[2]
   int tdc;  // int16u in word[2]
   std::vector<int16_t> electrodes;  // int16u in word[2]
-  boost::circular_buffer<int16_t> pac_buffer_; // 2.2kHz history of int16u/word[2] values. Capacity of 270 samples is 10 read cycles, or 122ms history
+  boost::circular_buffer<int16_t> pac_buffer_;  // 2.2kHz history of int16u/word[2] values. Capacity of 270 samples is
+                                                // 10 read cycles, or 122ms history
   static const size_t pac_size_ = 270;
 
 private:
   std::vector<int16_t> pac_vector_;
-
 };
 
 class UBI0Data

--- a/sr_hardware_interface/include/sr_hardware_interface/tactile_sensors.hpp
+++ b/sr_hardware_interface/include/sr_hardware_interface/tactile_sensors.hpp
@@ -33,6 +33,8 @@
 #include <boost/array.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/find_iterator.hpp>
+#include <boost/circular_buffer.hpp>
+#include <boost/thread/mutex.hpp>
 #include <sstream>
 
 #include <ros/ros.h>
@@ -235,6 +237,9 @@ public:
   BiotacData()
           : GenericTactileData()
   {
+    pac_buffer_ = boost::circular_buffer<int16_t>(pac_size_);
+    pac_vector_.reserve(pac_size_);
+    pac_mutex_ = new boost::mutex();
   };
 
   BiotacData(const BiotacData &btac)
@@ -244,14 +249,13 @@ public:
                                btac.software_version_server,
                                btac.software_version_modified,
                                btac.pcb_version),
-            pac0(btac.pac0), pac1(btac.pac1),
             pdc(btac.pdc), tac(btac.tac),
             tdc(btac.tdc)
   {
-    for (unsigned int i = 0; i < btac.electrodes.size(); i++)
-    {
-      electrodes[i] = btac.electrodes[i];
-    }
+    electrodes = std::vector<int16_t>(btac.electrodes);
+    pac_vector_ = std::vector<int16_t>(btac.pac_vector_);
+    pac_buffer_ = boost::circular_buffer<int16_t>(btac.pac_buffer_);
+    pac_mutex_ = new boost::mutex();
   };
 
   explicit BiotacData(const GenericTactileData &gtd)
@@ -262,20 +266,54 @@ public:
                                gtd.software_version_modified,
                                gtd.pcb_version)
   {
+    pac_buffer_ = boost::circular_buffer<int16_t>(pac_size_);
+    pac_vector_.reserve(pac_size_);
+    pac_mutex_ = new boost::mutex();
   };
 
   ~BiotacData()
   {
+    delete pac_mutex_;
   };
 
-  int pac0;  // always there, in word[0] and 1; int16u (2kHz)
-  int pac1;  // int16u
+  void add_pac(int16_t value)
+  {
+    pac_mutex_->lock();
+    pac_buffer_.push_back(value);
+    pac_mutex_->unlock();
+  }
+
+  std::vector<int16_t> get_pac(bool consume = false)
+  {
+    pac_vector_.clear();
+    pac_mutex_->lock();
+    pac_vector_.insert(pac_vector_.begin(), pac_buffer_.begin(), pac_buffer_.end());
+    if (consume)
+    {
+      pac_buffer_.clear();
+    }
+    pac_mutex_->unlock();
+    return pac_vector_;
+  }
+
+  std::vector<int16_t> consume_pac()
+  {
+    return get_pac(true);
+  }
+
 
   int pdc;  // int16u in word[2]
 
   int tac;  // int16u in word[2]
   int tdc;  // int16u in word[2]
   std::vector<int16_t> electrodes;  // int16u in word[2]
+
+private:
+  static const size_t pac_size_ = 270;
+  boost::circular_buffer<int16_t> pac_buffer_; // 2.2kHz history of int16u/word[2] values. Capacity of 270 samples is 10 read cycles, or 122ms history
+  std::vector<int16_t> pac_vector_;
+  boost::mutex * pac_mutex_;
+
 };
 
 class UBI0Data

--- a/sr_mechanism_controllers/example/srh_syntouch_controllers.cpp
+++ b/sr_mechanism_controllers/example/srh_syntouch_controllers.cpp
@@ -134,10 +134,10 @@ namespace controller
     // TACTILES
 
     // you have access here to the whole data coming from the 5 tactiles at full speed.
-    double my_first_finger_tactile_pac0 = actuator_->motor_state_.tactiles_->at(0).biotac.pac0;
+    double my_first_finger_tactile_pac = actuator_->motor_state_.tactiles_->at(0).biotac.get_pac().back();
     if (loop_count_ % 10 == 0)
     {
-      ROS_ERROR_STREAM("PAC0, tactile " << my_first_finger_tactile_pac0);
+      ROS_ERROR_STREAM("PAC, tactile " << my_first_finger_tactile_pac);
     }
 
     ////////////


### PR DESCRIPTION

Modifying biotac driver to store Pac values in a pre-allocated circular buffer, and allow consumption of those values (e.g. by a separate publisher).