### PR TITLE
moved the read_parameters call to init, so that it gets called by the…

### DIFF
--- a/sr_mechanism_controllers/src/srh_joint_position_controller.cpp
+++ b/sr_mechanism_controllers/src/srh_joint_position_controller.cpp
@@ -122,6 +122,8 @@ namespace controller
     serve_set_gains_ = node_.advertiseService("set_gains", &SrhJointPositionController::setGains, this);
     serve_reset_gains_ = node_.advertiseService("reset_gains", &SrhJointPositionController::resetGains, this);
 
+    read_parameters();
+
     after_init();
     return true;
   }
@@ -130,7 +132,6 @@ namespace controller
   {
     resetJointState();
     pid_controller_position_->reset();
-    read_parameters();
 
     if (has_j2)
       ROS_WARN_STREAM(


### PR DESCRIPTION
… non-realtime loop in ros_control_robot during setup, so that it doesn't cause a delay that makes the arm time-out

## Proposed changes

The call to read_parameters for each controller for the hand took too long (over 20ms in total), and as it was called by the realtime thread it interrupted communications to the arm (when used in combined_robot_hw), which was set to timeout after 20ms. Moving this call to the end of init makes it get called by the non-realtime thread instead, stopping it from interrupting communications with the arm during startup.

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. This is a reminder of what we should look for before merging this code. I have:_ 

- [x] Read and follow the [contributing guidelines](https://github.com/shadow-robot/sr_documentation/blob/master/CONTRIBUTING.md).
- [x] Checked that all tests pass with my changes
- [ ] Added tests (automatic or manual) that prove the fix is effective or that the feature works
- [ ] Added necessary documentation (if appropriate)
- [ ] Added the corresponding license to each file and add the current year of any one that you modified.
- [x] Tested on real hardware (if appropriate)
