### PR TITLE
Fixed timeout in python test (#169) and reduced CPU load while waiting

### DIFF
--- a/sr_utilities/test/test_hand_finder.py
+++ b/sr_utilities/test/test_hand_finder.py
@@ -44,7 +44,7 @@ class TestHandFinder(unittest.TestCase):
         if rospy.has_param("robot_description"):
             rospy.delete_param("robot_description")
 
-        hand_finder = HandFinder()
+        hand_finder = HandFinder(1.0)
 
         self.assertEqual(len(hand_finder.get_hand_parameters().joint_prefix), 0, "correct parameters without a hand")
         self.assertEqual(len(hand_finder.get_hand_parameters().mapping), 0, "correct parameters without a hand")
@@ -66,7 +66,7 @@ class TestHandFinder(unittest.TestCase):
         rospy.set_param("hand/joint_prefix/1", "rh_")
         rospy.set_param("hand/mapping/1", "right")
 
-        hand_finder = HandFinder()
+        hand_finder = HandFinder(1.0)
         # hand params
         self.assertIsNotNone(hand_finder.get_hand_parameters(), "Parameters extracted.")
         self.assertEqual(len(hand_finder.get_hand_parameters().mapping), 1, "It should be only one mapping")
@@ -111,7 +111,7 @@ class TestHandFinder(unittest.TestCase):
         rospy.set_param("hand/joint_prefix/1", "rh_")
         rospy.set_param("hand/mapping/1", "")
 
-        hand_finder = HandFinder()
+        hand_finder = HandFinder(1.0)
         # hand params
         self.assertIsNotNone(hand_finder.get_hand_parameters(), "Parameters extracted.")
         self.assertEqual(len(hand_finder.get_hand_parameters().mapping), 1, "It should be only one mapping")
@@ -157,7 +157,7 @@ class TestHandFinder(unittest.TestCase):
         rospy.set_param("hand/joint_prefix/1", "")
         rospy.set_param("hand/mapping/1", "rh")
 
-        hand_finder = HandFinder()
+        hand_finder = HandFinder(1.0)
         # hand params
         self.assertIsNotNone(hand_finder.get_hand_parameters(), "Parameters extracted.")
         self.assertEqual(len(hand_finder.get_hand_parameters().mapping), 1, "It should be only one mapping")
@@ -202,7 +202,7 @@ class TestHandFinder(unittest.TestCase):
         rospy.set_param("hand/joint_prefix/1", "")
         rospy.set_param("hand/mapping/1", "")
 
-        hand_finder = HandFinder()
+        hand_finder = HandFinder(1.0)
         # hand params
         self.assertIsNotNone(hand_finder.get_hand_parameters(), "Parameters extracted.")
         self.assertEqual(len(hand_finder.get_hand_parameters().mapping), 1, "It should be only one mapping")
@@ -249,7 +249,7 @@ class TestHandFinder(unittest.TestCase):
         rospy.set_param("hand/joint_prefix/2", "lh_")
         rospy.set_param("hand/mapping/2", "left")
 
-        hand_finder = HandFinder()
+        hand_finder = HandFinder(1.0)
 
         # hand params
         self.assertIsNotNone(hand_finder.get_hand_parameters(), "Parameters extracted.")
@@ -320,7 +320,7 @@ class TestHandFinder(unittest.TestCase):
 
         rospy.set_param("robot_description", rospy.get_param("two_hands_description"))
 
-        hand_finder = HandFinder()
+        hand_finder = HandFinder(1.0)
 
         self.assertEqual(len(hand_finder.get_hand_parameters().joint_prefix), 0, "correct parameters without a hand")
         self.assertEqual(len(hand_finder.get_hand_parameters().mapping), 0, "correct parameters without a hand")
@@ -343,7 +343,7 @@ class TestHandFinder(unittest.TestCase):
         rospy.set_param("hand/mapping/1", "right")
         rospy.set_param("robot_description", rospy.get_param("right_hand_description"))
 
-        hand_finder = HandFinder()
+        hand_finder = HandFinder(1.0)
         # hand params
         self.assertIsNotNone(hand_finder.get_hand_parameters(), "Parameters extracted.")
         self.assertEqual(len(hand_finder.get_hand_parameters().mapping), 1, "It should be only one mapping")
@@ -391,7 +391,7 @@ class TestHandFinder(unittest.TestCase):
         rospy.set_param("hand/mapping/1", "")
         rospy.set_param("robot_description", rospy.get_param("right_hand_description"))
 
-        hand_finder = HandFinder()
+        hand_finder = HandFinder(1.0)
         # hand params
         self.assertIsNotNone(hand_finder.get_hand_parameters(), "Parameters extracted.")
         self.assertEqual(len(hand_finder.get_hand_parameters().mapping), 1, "It should be only one mapping")
@@ -438,7 +438,7 @@ class TestHandFinder(unittest.TestCase):
         rospy.set_param("hand/mapping/1", "rh")
         rospy.set_param("robot_description", rospy.get_param("right_hand_description_no_prefix"))
 
-        hand_finder = HandFinder()
+        hand_finder = HandFinder(1.0)
         # hand params
         self.assertIsNotNone(hand_finder.get_hand_parameters(), "Parameters extracted.")
         self.assertEqual(len(hand_finder.get_hand_parameters().mapping), 1, "It should be only one mapping")
@@ -485,7 +485,7 @@ class TestHandFinder(unittest.TestCase):
         rospy.set_param("hand/mapping/1", "")
         rospy.set_param("robot_description", rospy.get_param("right_hand_description_no_prefix"))
 
-        hand_finder = HandFinder()
+        hand_finder = HandFinder(1.0)
         # hand params
         self.assertIsNotNone(hand_finder.get_hand_parameters(), "Parameters extracted.")
         self.assertEqual(len(hand_finder.get_hand_parameters().mapping), 1, "It should be only one mapping")
@@ -534,7 +534,7 @@ class TestHandFinder(unittest.TestCase):
         rospy.set_param("hand/mapping/2", "left")
         rospy.set_param("robot_description", rospy.get_param("two_hands_description"))
 
-        hand_finder = HandFinder()
+        hand_finder = HandFinder(1.0)
         # hand params
         self.assertIsNotNone(hand_finder.get_hand_parameters(), "Parameters extracted.")
         self.assertEqual(len(hand_finder.get_hand_parameters().mapping), 2, "It should be two mappings")


### PR DESCRIPTION
## Proposed changes

Fixes #169 and additionally put some sleep to avoid high CPU load while waiting for parameters.

Test works now
```
[sr_utilities.rosunit-test_hand_finder_cpp/hand_absent_test][passed]
[sr_utilities.rosunit-test_hand_finder_cpp/one_hand_no_robot_description_finder_test][passed]
[sr_utilities.rosunit-test_hand_finder_cpp/one_hand_no_mapping_no_robot_description_finder_test][passed]
[sr_utilities.rosunit-test_hand_finder_cpp/one_hand_no_prefix_no_robot_description_finder_test][passed]
[sr_utilities.rosunit-test_hand_finder_cpp/one_hand_no_mapping_no_prefix_no_robot_description_finder_test][passed]
[sr_utilities.rosunit-test_hand_finder_cpp/one_hand_robot_description_exists_finger_test][passed]
[sr_utilities.rosunit-test_hand_finder_cpp/two_hand_robot_description_exists_finder_test][passed]
[sr_utilities.rosunit-test_hand_finder_py/test_no_hand_no_robot_description_finder][passed]
[sr_utilities.rosunit-test_hand_finder_py/test_no_hand_robot_description_exists_finder][passed]
[sr_utilities.rosunit-test_hand_finder_py/test_one_hand_no_mapping_no_robot_description_finder][passed]
[sr_utilities.rosunit-test_hand_finder_py/test_one_hand_no_mapping_robot_description_exists_finder][passed]
[sr_utilities.rosunit-test_hand_finder_py/test_one_hand_no_prefix_no_mapping_no_robot_description_finder][passed]
[sr_utilities.rosunit-test_hand_finder_py/test_one_hand_no_prefix_no_ns_robot_description_exists_finder][passed]
[sr_utilities.rosunit-test_hand_finder_py/test_one_hand_no_prefix_no_robot_description_finder][passed]
[sr_utilities.rosunit-test_hand_finder_py/test_one_hand_no_prefix_robot_description_exists_finder][passed]
[sr_utilities.rosunit-test_hand_finder_py/test_one_hand_no_robot_description_finder][passed]
[sr_utilities.rosunit-test_hand_finder_py/test_one_hand_robot_description_exists_finder][passed]
[sr_utilities.rosunit-test_hand_finder_py/test_two_hand_no_robot_description_finder][passed]
[sr_utilities.rosunit-test_hand_finder_py/test_two_hand_robot_description_exists_finder][passed]

SUMMARY
 * RESULT: SUCCESS
 * TESTS: 19
 * ERRORS: 0
 * FAILURES: 0
```

## Checklist

If the task is applicable to this pull request (see applicability criteria in brackets), make sure it is completed before checking the corresponding box. Otherwise, tick the box right away. Make sure that **ALL** boxes are checked **BEFORE** the PR is merged.

- [x] Manually tested that added code works as intended (if any functional/runnable code is added).
- [x] Added automated tests (if a new class is added (Python or C++), interface of that class must be unit tested).
- [ ] Tested on real hardware (if the changed or added code is used with the real hardware).
- [x] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc.)
