### PR TITLE
B#171 handfinder ns

### DIFF
--- a/sr_utilities/test/test_hand_finder.cpp
+++ b/sr_utilities/test/test_hand_finder.cpp
@@ -54,9 +54,9 @@ void ASSERT_MAP_HAS_VALUE(const map<string, string> &map, const string &value)
 
 TEST(SrHandFinder, hand_absent_test)
 {
-  if (ros::param::has("hand"))
+  if (ros::param::has("/hand"))
   {
-    ros::param::del("hand");
+    ros::param::del("/hand");
   }
 
   if (ros::param::has("robot_description"))
@@ -77,9 +77,9 @@ TEST(SrHandFinder, hand_absent_test)
 
 TEST(SrHandFinder, one_hand_no_robot_description_finder_test)
 {
-  if (ros::param::has("hand"))
+  if (ros::param::has("/hand"))
   {
-    ros::param::del("hand");
+    ros::param::del("/hand");
   }
 
   if (ros::param::has("robot_description"))
@@ -87,8 +87,8 @@ TEST(SrHandFinder, one_hand_no_robot_description_finder_test)
     ros::param::del("robot_description");
   }
 
-  ros::param::set("hand/mapping/1", "right");
-  ros::param::set("hand/joint_prefix/1", "rh_");
+  ros::param::set("/hand/mapping/1", "right");
+  ros::param::set("/hand/joint_prefix/1", "rh_");
 
   string ethercat_path = ros::package::getPath("sr_ethercat_hand_config");
   const string joint_names[] =
@@ -166,9 +166,9 @@ TEST(SrHandFinder, one_hand_no_robot_description_finder_test)
 
 TEST(SrHandFinder, one_hand_no_mapping_no_robot_description_finder_test)
 {
-  if (ros::param::has("hand"))
+  if (ros::param::has("/hand"))
   {
-    ros::param::del("hand");
+    ros::param::del("/hand");
   }
 
   if (ros::param::has("robot_description"))
@@ -176,8 +176,8 @@ TEST(SrHandFinder, one_hand_no_mapping_no_robot_description_finder_test)
     ros::param::del("robot_description");
   }
 
-  ros::param::set("hand/mapping/1", "");
-  ros::param::set("hand/joint_prefix/1", "rh_");
+  ros::param::set("/hand/mapping/1", "");
+  ros::param::set("/hand/joint_prefix/1", "rh_");
 
   string ethercat_path = ros::package::getPath("sr_ethercat_hand_config");
   const string joint_names[] =
@@ -254,9 +254,9 @@ TEST(SrHandFinder, one_hand_no_mapping_no_robot_description_finder_test)
 
 TEST(SrHandFinder, one_hand_no_prefix_no_robot_description_finder_test)
 {
-  if (ros::param::has("hand"))
+  if (ros::param::has("/hand"))
   {
-    ros::param::del("hand");
+    ros::param::del("/hand");
   }
 
   if (ros::param::has("robot_description"))
@@ -264,8 +264,8 @@ TEST(SrHandFinder, one_hand_no_prefix_no_robot_description_finder_test)
     ros::param::del("robot_description");
   }
 
-  ros::param::set("hand/mapping/1", "rh");
-  ros::param::set("hand/joint_prefix/1", "");
+  ros::param::set("/hand/mapping/1", "rh");
+  ros::param::set("/hand/joint_prefix/1", "");
 
   string ethercat_path = ros::package::getPath("sr_ethercat_hand_config");
   const string joint_names[] =
@@ -342,9 +342,9 @@ TEST(SrHandFinder, one_hand_no_prefix_no_robot_description_finder_test)
 
 TEST(SrHandFinder, one_hand_no_mapping_no_prefix_no_robot_description_finder_test)
 {
-  if (ros::param::has("hand"))
+  if (ros::param::has("/hand"))
   {
-    ros::param::del("hand");
+    ros::param::del("/hand");
   }
 
   if (ros::param::has("robot_description"))
@@ -352,8 +352,8 @@ TEST(SrHandFinder, one_hand_no_mapping_no_prefix_no_robot_description_finder_tes
     ros::param::del("robot_description");
   }
 
-  ros::param::set("hand/mapping/1", "");
-  ros::param::set("hand/joint_prefix/1", "");
+  ros::param::set("/hand/mapping/1", "");
+  ros::param::set("/hand/joint_prefix/1", "");
 
   string ethercat_path = ros::package::getPath("sr_ethercat_hand_config");
   const string joint_names[] =
@@ -430,9 +430,9 @@ TEST(SrHandFinder, one_hand_no_mapping_no_prefix_no_robot_description_finder_tes
 
 TEST(SrHandFinder, one_hand_robot_description_exists_finger_test)
 {
-  if (ros::param::has("hand"))
+  if (ros::param::has("/hand"))
   {
-    ros::param::del("hand");
+    ros::param::del("/hand");
   }
 
   if (ros::param::has("robot_description"))
@@ -441,11 +441,11 @@ TEST(SrHandFinder, one_hand_robot_description_exists_finger_test)
   }
 
   string right_hand_description;
-  ros::param::get("right_hand_description", right_hand_description);
+  ros::param::get("/right_hand_description", right_hand_description);
   ros::param::set("robot_description", right_hand_description);
 
-  ros::param::set("hand/mapping/1", "right");
-  ros::param::set("hand/joint_prefix/1", "rh_");
+  ros::param::set("/hand/mapping/1", "right");
+  ros::param::set("/hand/joint_prefix/1", "rh_");
   string ethercat_path = ros::package::getPath("sr_ethercat_hand_config");
   const string joint_names[] =
   {
@@ -519,9 +519,9 @@ TEST(SrHandFinder, one_hand_robot_description_exists_finger_test)
 
 TEST(SrHandFinder, two_hand_robot_description_exists_finder_test)
 {
-  if (ros::param::has("hand"))
+  if (ros::param::has("/hand"))
   {
-    ros::param::del("hand");
+    ros::param::del("/hand");
   }
 
   if (ros::param::has("robot_description"))
@@ -529,13 +529,13 @@ TEST(SrHandFinder, two_hand_robot_description_exists_finder_test)
     ros::param::del("robot_description");
   }
 
-  ros::param::set("hand/mapping/1", "right");
-  ros::param::set("hand/joint_prefix/1", "rh_");
-  ros::param::set("hand/mapping/2", "left");
-  ros::param::set("hand/joint_prefix/2", "lh_");
+  ros::param::set("/hand/mapping/1", "right");
+  ros::param::set("/hand/joint_prefix/1", "rh_");
+  ros::param::set("/hand/mapping/2", "left");
+  ros::param::set("/hand/joint_prefix/2", "lh_");
 
   string two_hands_description;
-  ros::param::get("two_hands_description", two_hands_description);
+  ros::param::get("/two_hands_description", two_hands_description);
   ros::param::set("robot_description", two_hands_description);
 
   const string joint_names[] =

--- a/sr_utilities/test/test_hand_finder.py
+++ b/sr_utilities/test/test_hand_finder.py
@@ -38,8 +38,8 @@ class TestHandFinder(unittest.TestCase):
     ethercat_path = rospack.get_path('sr_ethercat_hand_config')
 
     def test_no_hand_no_robot_description_finder(self):
-        if rospy.has_param("hand"):
-            rospy.delete_param("hand")
+        if rospy.has_param("/hand"):
+            rospy.delete_param("/hand")
 
         if rospy.has_param("robot_description"):
             rospy.delete_param("robot_description")
@@ -57,14 +57,14 @@ class TestHandFinder(unittest.TestCase):
                          "correct tuning without a hands")
 
     def test_one_hand_no_robot_description_finder(self):
-        if rospy.has_param("hand"):
-            rospy.delete_param("hand")
+        if rospy.has_param("/hand"):
+            rospy.delete_param("/hand")
 
         if rospy.has_param("robot_description"):
             rospy.delete_param("robot_description")
 
-        rospy.set_param("hand/joint_prefix/1", "rh_")
-        rospy.set_param("hand/mapping/1", "right")
+        rospy.set_param("/hand/joint_prefix/1", "rh_")
+        rospy.set_param("/hand/mapping/1", "right")
 
         hand_finder = HandFinder(1.0)
         # hand params
@@ -102,14 +102,14 @@ class TestHandFinder(unittest.TestCase):
                              "incorrect controller config file")
 
     def test_one_hand_no_mapping_no_robot_description_finder(self):
-        if rospy.has_param("hand"):
-            rospy.delete_param("hand")
+        if rospy.has_param("/hand"):
+            rospy.delete_param("/hand")
 
         if rospy.has_param("robot_description"):
             rospy.delete_param("robot_description")
 
-        rospy.set_param("hand/joint_prefix/1", "rh_")
-        rospy.set_param("hand/mapping/1", "")
+        rospy.set_param("/hand/joint_prefix/1", "rh_")
+        rospy.set_param("/hand/mapping/1", "")
 
         hand_finder = HandFinder(1.0)
         # hand params
@@ -148,14 +148,14 @@ class TestHandFinder(unittest.TestCase):
                              "incorrect controller config file")
 
     def test_one_hand_no_prefix_no_robot_description_finder(self):
-        if rospy.has_param("hand"):
-            rospy.delete_param("hand")
+        if rospy.has_param("/hand"):
+            rospy.delete_param("/hand")
 
         if rospy.has_param("robot_description"):
             rospy.delete_param("robot_description")
 
-        rospy.set_param("hand/joint_prefix/1", "")
-        rospy.set_param("hand/mapping/1", "rh")
+        rospy.set_param("/hand/joint_prefix/1", "")
+        rospy.set_param("/hand/mapping/1", "rh")
 
         hand_finder = HandFinder(1.0)
         # hand params
@@ -193,14 +193,14 @@ class TestHandFinder(unittest.TestCase):
                              "incorrect controller config file")
 
     def test_one_hand_no_prefix_no_mapping_no_robot_description_finder(self):
-        if rospy.has_param("hand"):
-            rospy.delete_param("hand")
+        if rospy.has_param("/hand"):
+            rospy.delete_param("/hand")
 
         if rospy.has_param("robot_description"):
             rospy.delete_param("robot_description")
 
-        rospy.set_param("hand/joint_prefix/1", "")
-        rospy.set_param("hand/mapping/1", "")
+        rospy.set_param("/hand/joint_prefix/1", "")
+        rospy.set_param("/hand/mapping/1", "")
 
         hand_finder = HandFinder(1.0)
         # hand params
@@ -238,16 +238,16 @@ class TestHandFinder(unittest.TestCase):
                              "incorrect controller config file")
 
     def test_two_hand_no_robot_description_finder(self):
-        if rospy.has_param("hand"):
-            rospy.delete_param("hand")
+        if rospy.has_param("/hand"):
+            rospy.delete_param("/hand")
 
         if rospy.has_param("robot_description"):
             rospy.delete_param("robot_description")
 
-        rospy.set_param("hand/joint_prefix/1", "rh_")
-        rospy.set_param("hand/mapping/1", "right")
-        rospy.set_param("hand/joint_prefix/2", "lh_")
-        rospy.set_param("hand/mapping/2", "left")
+        rospy.set_param("/hand/joint_prefix/1", "rh_")
+        rospy.set_param("/hand/mapping/1", "right")
+        rospy.set_param("/hand/joint_prefix/2", "lh_")
+        rospy.set_param("/hand/mapping/2", "left")
 
         hand_finder = HandFinder(1.0)
 
@@ -312,13 +312,13 @@ class TestHandFinder(unittest.TestCase):
                              "incorrect controller config file")
 
     def test_no_hand_robot_description_exists_finder(self):
-        if rospy.has_param("hand"):
-            rospy.delete_param("hand")
+        if rospy.has_param("/hand"):
+            rospy.delete_param("/hand")
 
         if rospy.has_param("robot_description"):
             rospy.delete_param("robot_description")
 
-        rospy.set_param("robot_description", rospy.get_param("two_hands_description"))
+        rospy.set_param("robot_description", rospy.get_param("/two_hands_description"))
 
         hand_finder = HandFinder(1.0)
 
@@ -333,15 +333,15 @@ class TestHandFinder(unittest.TestCase):
                          "correct tuning without a hands")
 
     def test_one_hand_robot_description_exists_finder(self):
-        if rospy.has_param("hand"):
-            rospy.delete_param("hand")
+        if rospy.has_param("/hand"):
+            rospy.delete_param("/hand")
 
         if rospy.has_param("robot_description"):
             rospy.delete_param("robot_description")
 
-        rospy.set_param("hand/joint_prefix/1", "rh_")
-        rospy.set_param("hand/mapping/1", "right")
-        rospy.set_param("robot_description", rospy.get_param("right_hand_description"))
+        rospy.set_param("/hand/joint_prefix/1", "rh_")
+        rospy.set_param("/hand/mapping/1", "right")
+        rospy.set_param("robot_description", rospy.get_param("/right_hand_description"))
 
         hand_finder = HandFinder(1.0)
         # hand params
@@ -381,15 +381,15 @@ class TestHandFinder(unittest.TestCase):
                              "incorrect controller config file")
 
     def test_one_hand_no_mapping_robot_description_exists_finder(self):
-        if rospy.has_param("hand"):
-            rospy.delete_param("hand")
+        if rospy.has_param("/hand"):
+            rospy.delete_param("/hand")
 
         if rospy.has_param("robot_description"):
             rospy.delete_param("robot_description")
 
-        rospy.set_param("hand/joint_prefix/1", "rh_")
-        rospy.set_param("hand/mapping/1", "")
-        rospy.set_param("robot_description", rospy.get_param("right_hand_description"))
+        rospy.set_param("/hand/joint_prefix/1", "rh_")
+        rospy.set_param("/hand/mapping/1", "")
+        rospy.set_param("robot_description", rospy.get_param("/right_hand_description"))
 
         hand_finder = HandFinder(1.0)
         # hand params
@@ -428,15 +428,15 @@ class TestHandFinder(unittest.TestCase):
                              "incorrect controller config file")
 
     def test_one_hand_no_prefix_robot_description_exists_finder(self):
-        if rospy.has_param("hand"):
-            rospy.delete_param("hand")
+        if rospy.has_param("/hand"):
+            rospy.delete_param("/hand")
 
         if rospy.has_param("robot_description"):
             rospy.delete_param("robot_description")
 
-        rospy.set_param("hand/joint_prefix/1", "")
-        rospy.set_param("hand/mapping/1", "rh")
-        rospy.set_param("robot_description", rospy.get_param("right_hand_description_no_prefix"))
+        rospy.set_param("/hand/joint_prefix/1", "")
+        rospy.set_param("/hand/mapping/1", "rh")
+        rospy.set_param("robot_description", rospy.get_param("/right_hand_description_no_prefix"))
 
         hand_finder = HandFinder(1.0)
         # hand params
@@ -475,15 +475,15 @@ class TestHandFinder(unittest.TestCase):
                              "incorrect controller config file")
 
     def test_one_hand_no_prefix_no_ns_robot_description_exists_finder(self):
-        if rospy.has_param("hand"):
-            rospy.delete_param("hand")
+        if rospy.has_param("/hand"):
+            rospy.delete_param("/hand")
 
         if rospy.has_param("robot_description"):
             rospy.delete_param("robot_description")
 
-        rospy.set_param("hand/joint_prefix/1", "")
-        rospy.set_param("hand/mapping/1", "")
-        rospy.set_param("robot_description", rospy.get_param("right_hand_description_no_prefix"))
+        rospy.set_param("/hand/joint_prefix/1", "")
+        rospy.set_param("/hand/mapping/1", "")
+        rospy.set_param("robot_description", rospy.get_param("/right_hand_description_no_prefix"))
 
         hand_finder = HandFinder(1.0)
         # hand params
@@ -522,17 +522,17 @@ class TestHandFinder(unittest.TestCase):
                              "incorrect controller config file")
 
     def test_two_hand_robot_description_exists_finder(self):
-        if rospy.has_param("hand"):
-            rospy.delete_param("hand")
+        if rospy.has_param("/hand"):
+            rospy.delete_param("/hand")
 
         if rospy.has_param("robot_description"):
             rospy.delete_param("robot_description")
 
-        rospy.set_param("hand/joint_prefix/1", "rh_")
-        rospy.set_param("hand/mapping/1", "right")
-        rospy.set_param("hand/joint_prefix/2", "lh_")
-        rospy.set_param("hand/mapping/2", "left")
-        rospy.set_param("robot_description", rospy.get_param("two_hands_description"))
+        rospy.set_param("/hand/joint_prefix/1", "rh_")
+        rospy.set_param("/hand/mapping/1", "right")
+        rospy.set_param("/hand/joint_prefix/2", "lh_")
+        rospy.set_param("/hand/mapping/2", "left")
+        rospy.set_param("robot_description", rospy.get_param("/two_hands_description"))
 
         hand_finder = HandFinder(1.0)
         # hand params

--- a/sr_utilities/test/test_hand_finder.test
+++ b/sr_utilities/test/test_hand_finder.test
@@ -4,6 +4,10 @@
   <param name="right_hand_description_no_prefix" textfile="$(find sr_utilities)/test/urdf/right_hand_description_no_prefix.urdf" />
   <param name="two_hands_description" textfile="$(find sr_utilities)/test/urdf/two_hands_description.urdf" />
 
-  <test test-name="test_hand_finder_cpp" pkg="sr_utilities" type="test_hand_finder"/>
+  <test test-name="test_hand_finder_cpp" pkg="sr_utilities" type="test_hand_finder" />
   <test test-name="test_hand_finder_py" pkg="sr_utilities" type="test_hand_finder.py" />
+  <group ns="mynamespace">
+    <test test-name="namespaced_test_hand_finder_cpp" pkg="sr_utilities" type="test_hand_finder" />
+    <test test-name="namespaced_test_hand_finder_py" pkg="sr_utilities" type="test_hand_finder.py" />
+  </group>
 </launch>


### PR DESCRIPTION
## Proposed changes

Adds tests to find bug reported in #171 and remain compatible to convention
* hand parameters are on the root but use hand_id to avoid overlap for multiple hands
*  robot description parameters can be namespaced to avoid overlap for multiple hands on different drivers

## Checklist

If the task is applicable to this pull request (see applicability criteria in brackets), make sure it is completed before checking the corresponding box. Otherwise, tick the box right away. Make sure that **ALL** boxes are checked **BEFORE** the PR is merged.

- [x] Manually tested that added code works as intended (if any functional/runnable code is added).
- [x] Added automated tests (if a new class is added (Python or C++), interface of that class must be unit tested).
- [ ] **PARTIAL only on namespaced hands** Tested on real hardware (if the changed or added code is used with the real hardware).
- [x] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc.)
