### PR TITLE
SRC-4962 Propagate command type from joint state to actuator

### DIFF
--- a/sr_mechanism_model/src/simple_transmission.cpp
+++ b/sr_mechanism_model/src/simple_transmission.cpp
@@ -90,8 +90,9 @@ namespace sr_mechanism_model
   {
     SrMotorActuator *act = static_cast<SrMotorActuator *>(actuator_);
     act->command_.enable_ = true;
-    act->command_.effort_ = joint_->commanded_effort_;
-    act->command_.type_ = joint_->actuator_command_type_;
+    act->command_.set_effort_command(
+      joint_->commanded_effort_,
+      joint_->effort_command_type_);
   }
 
 }  // namespace sr_mechanism_model

--- a/sr_mechanism_model/src/simple_transmission.cpp
+++ b/sr_mechanism_model/src/simple_transmission.cpp
@@ -91,6 +91,7 @@ namespace sr_mechanism_model
     SrMotorActuator *act = static_cast<SrMotorActuator *>(actuator_);
     act->command_.enable_ = true;
     act->command_.effort_ = joint_->commanded_effort_;
+    act->command_.type_ = joint_->actuator_command_type_;
   }
 
 }  // namespace sr_mechanism_model


### PR DESCRIPTION
## Proposed changes

Propagate command type from joint state to actuator so that controllers can indicate what commanded effort means.

## Checklist

If the task is applicable to this pull request (see applicability criteria in brackets), make sure it is completed before checking the corresponding box. Otherwise, tick the box right away. Make sure that **ALL** boxes are checked **BEFORE** the PR is merged.

- [x] Manually tested that added code works as intended (if any functional/runnable code is added).
- [x] Added automated tests (if a new class is added (Python or C++), interface of that class must be unit tested).
- [x] Tested on real hardware (if the changed or added code is used with the real hardware).
- [x] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc.)
