### PR TITLE
Restricted the listing to reset services in the current namespace

### DIFF
--- a/sr_utilities/scripts/sr_utilities/calibrate_hand_finder.py
+++ b/sr_utilities/scripts/sr_utilities/calibrate_hand_finder.py
@@ -38,11 +38,12 @@ class CalibrateHand(object):
         generated_reset_service_list = []
         service_list = []
 
-        # We first read the list of available motor reset services
+        # We first read the list of available motor reset services in this namespace
         # this will allow us to avoid having to know the name of the robot driver node
+        ns = rospy.get_namespace()
         while not reset_service_list:
             rospy.sleep(0.5)
-            service_list = rosservice.get_service_list()
+            service_list = rosservice.get_service_list(namespace=ns)
             reset_service_list = [srv for srv in service_list if '/reset_motor_' in srv]
             if not reset_service_list:
                 rospy.loginfo("Waiting for motor reset services")


### PR DESCRIPTION
## Proposed changes

Fixes https://github.com/shadow-robot/sr-ros-interface-ethercat/issues/247 by testing the namespace in which the calibrate hand  is started to restrict the list of reset services found. 
Works for our dual namespaced hands and for a non-namespaced realtime loop.

I did not yet migrate to noetic so cannot test on noetic, but I believe a cherry-pick is possible as the change is minimal.

It is not perfect because if one hand is in a namespace and another hand is not, then the one without namespace will obviously again find all services of both non-namespaced and namespaced hands. 

I suppose one could parse the prefix and at least warn if services are found for multiple prefix. A cleaner fix should be done, but this PR is a first step and I let you decide how to improve if needed.

## Tests

- [x] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added automated tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [ ] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [x] Manually tested on hardware (if hardware specific or related).

## Documentation

- [x] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
