### PR TITLE
Trivial cleanups

### DIFF
--- a/sr_gazebo_sim/gazebo_sim_plugin.xml
+++ b/sr_gazebo_sim/gazebo_sim_plugin.xml
@@ -1,4 +1,4 @@
-<library path="lib/libsr_gazebo_sim">
+<library path="libsr_gazebo_sim">
     <class name="sr_gazebo_sim/SrGazeboHWSim" type="sr_gazebo_sim::SrGazeboHWSim"
            base_class_type="gazebo_ros_control::RobotHWSim">
         <description>This simulated hardware creates and updates fake RobotState for ethercat based controllers.

--- a/sr_hand/launch/advanced/sr_arm_CAN_noTF.launch
+++ b/sr_hand/launch/advanced/sr_arm_CAN_noTF.launch
@@ -1,7 +1,7 @@
 <launch>
   <!-- DO NOT USE ROBOT DESCRIPTION IF NOT NEEDED  <param name="robot_description" command="xacro '$(find sr_description)/robots/arm_and_hand_motor.urdf.xacro'" /> -->
   <param name="sa_description"
-  command="xacro --inorder '$(find sr_description)/robots/sr_arm_motor.urdf.xacro'" />
+  command="xacro '$(find sr_description)/robots/sr_arm_motor.urdf.xacro'" />
   <!--
            shadowarm
                         -->

--- a/sr_hand/launch/gazebo/gazebo_arm.launch
+++ b/sr_hand/launch/gazebo/gazebo_arm.launch
@@ -11,11 +11,11 @@
   <!-- spawn the arm model -->
   <group if="$(optenv MUSCLE 0)">
     <param name="robot_description"
-    command="xacro --inorder '$(find sr_description)/robots/sr_arm_muscle.urdf.xacro'" />
+    command="xacro '$(find sr_description)/robots/sr_arm_muscle.urdf.xacro'" />
   </group>
   <group unless="$(optenv MUSCLE 0)">
     <param name="robot_description"
-    command="xacro --inorder '$(find sr_description)/robots/sr_arm_motor.urdf.xacro'" />
+    command="xacro '$(find sr_description)/robots/sr_arm_motor.urdf.xacro'" />
   </group>
   <node name="spawn_hand" pkg="gazebo_ros" type="spawn_model"
   args="-urdf -param robot_description -z 0.0 -model shadow_model -J ShoulderJSwing 0.78 -J ElbowJSwing 2.0"

--- a/sr_hand/launch/gazebo/gazebo_arm_and_hand.launch
+++ b/sr_hand/launch/gazebo/gazebo_arm_and_hand.launch
@@ -49,10 +49,10 @@
   <group if="$(arg set_arm_hand_description)">
     <!-- Loads the robot description from the file passed as an argument -->
     <param name="robot_description"
-    command="xacro --inorder '$(arg arm_hand_description)'" />
+    command="xacro '$(arg arm_hand_description)'" />
     <!-- Loads the robot description from the file passed as an argument -->
     <param name="sh_description"
-    command="xacro --inorder '$(arg hand_description)'" />
+    command="xacro '$(arg hand_description)'" />
   </group>
   <node name="spawn_hand" pkg="gazebo_ros" type="spawn_model"
   args="-urdf -param robot_description -z 0.0 -model shadow_model -J ShoulderJSwing 0.78 -J ElbowJSwing 2.0"

--- a/sr_hand/launch/gazebo/gazebo_hand.launch
+++ b/sr_hand/launch/gazebo/gazebo_hand.launch
@@ -51,9 +51,9 @@
   <group if="$(arg set_hand_description)">
     <!-- Loads the robot description from the file passed as an argument -->
     <param name="sh_description"
-    command="xacro --inorder '$(arg hand_description)'" />
+    command="xacro '$(arg hand_description)'" />
     <param name="robot_description"
-    command="xacro --inorder '$(arg hand_description)'" />
+    command="xacro '$(arg hand_description)'" />
   </group>
   <node name="spawn_hand" pkg="gazebo_ros" type="spawn_model"
   args="-urdf -param sh_description -z 0.01 -model shadow_model"

--- a/sr_hand/launch/rviz/rviz_motor.launch
+++ b/sr_hand/launch/rviz/rviz_motor.launch
@@ -2,5 +2,5 @@
   <node pkg="rviz" name="rviz_visualizer" type="rviz" />
   <include file="$(find sr_description)/loaders/load_hand_model.launch" />
   <param name="sa_description"
-  command="xacro --inorder '$(find sr_description)/robots/sr_arm_motor.urdf.xacro'" />
+  command="xacro '$(find sr_description)/robots/sr_arm_motor.urdf.xacro'" />
 </launch>

--- a/sr_hand/launch/rviz/rviz_muscle.launch
+++ b/sr_hand/launch/rviz/rviz_muscle.launch
@@ -1,7 +1,7 @@
 <launch>
   <param name="sh_description"
-  command="xacro --inorder '$(find sr_description)/robots/shadowhand_muscle.urdf.xacro'" />
+  command="xacro '$(find sr_description)/robots/shadowhand_muscle.urdf.xacro'" />
   <param name="sa_description"
-  command="xacro --inorder '$(find sr_description)/robots/sr_arm_muscle.urdf.xacro'" />
+  command="xacro '$(find sr_description)/robots/sr_arm_muscle.urdf.xacro'" />
   <node pkg="rviz" name="rviz_visualizer" type="rviz" />
 </launch>

--- a/sr_mechanism_controllers/controller_plugins.xml
+++ b/sr_mechanism_controllers/controller_plugins.xml
@@ -1,4 +1,4 @@
-<library path="lib/libsr_mechanism_controllers">
+<library path="libsr_mechanism_controllers">
     <class name="sr_mechanism_controllers/SrhJointPositionController"
            type="controller::SrhJointPositionController"
            base_class_type="controller_interface::ControllerBase"/>

--- a/sr_mechanism_model/transmission_plugin.xml
+++ b/sr_mechanism_model/transmission_plugin.xml
@@ -1,4 +1,4 @@
-<library path="lib/libsr_mechanism_model">
+<library path="libsr_mechanism_model">
     <class name="sr_mechanism_model/J0Transmission" type="sr_mechanism_model::J0Transmission"
            base_class_type="ros_ethercat_model::Transmission">
         <description>


### PR DESCRIPTION
## Proposed changes

This PR has two trivial commits we have lying around quite a while:
- Remove deprecated `--inorder` option for `xacro` to get rid of corresponding warnings
- Remove extra `lib/` prefix in `plugin.xml` (cosmetic change)

Both already apply to melodic-devel. Hence I'm targeting this branch. In any case, this should be forward-ported to Noetic as well.

## Tests

- [x] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added automated tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [ ] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [ ] Manually tested on hardware (if hardware specific or related).

## Documentation

- [x] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
