### PR TITLE
Fix friction compensation for a deadband of zero (or negative)

### DIFF
--- a/sr_mechanism_controllers/src/sr_friction_compensation.cpp
+++ b/sr_mechanism_controllers/src/sr_friction_compensation.cpp
@@ -56,6 +56,9 @@ namespace sr_friction_compensation
 
   double SrFrictionCompensator::friction_compensation(double position, double velocity, int force_demand, int deadband)
   {
+    if (deadband <= 0)
+      return 0.0;
+
     double compensation = 0.0;
 
     if (force_demand > 0.0)
@@ -226,5 +229,3 @@ namespace sr_friction_compensation
    c-basic-offset: 2
    End:
  */
-
-

--- a/sr_utilities/include/sr_utilities/sr_deadband.hpp
+++ b/sr_utilities/include/sr_utilities/sr_deadband.hpp
@@ -85,6 +85,9 @@ public:
                       double deadband_multiplicator = 5.0,
                       unsigned int nb_errors_for_avg = 50)
   {
+    if (deadband <= T(0))
+      return false;  // early return
+
     bool is_in_deadband = false;
 
     last_errors.push_back(error);


### PR DESCRIPTION
In this case, linear_interpolate doesn't return the expected result,
but either NaN or a negative value.