### PR TITLE
F fixing trajectory publisher bug

### DIFF
--- a/sr_utilities/CMakeLists.txt
+++ b/sr_utilities/CMakeLists.txt
@@ -3,7 +3,7 @@ project(sr_utilities)
 
 add_compile_options(-std=c++17)
 
-find_package(catkin REQUIRED COMPONENTS sensor_msgs sr_robot_msgs rospy roscpp tf urdf moveit_ros_planning_interface message_generation std_msgs)
+find_package(catkin REQUIRED COMPONENTS sensor_msgs sr_robot_msgs rospy roscpp tf urdf moveit_ros_planning_interface message_generation std_msgs sr_utilities_common)
 find_package(Boost REQUIRED COMPONENTS thread system)
 find_package(rostest REQUIRED)
 find_package(Eigen3 REQUIRED)
@@ -17,7 +17,7 @@ generate_messages(DEPENDENCIES std_msgs sensor_msgs)
 
 catkin_package(
         DEPENDS
-        CATKIN_DEPENDS sensor_msgs sr_robot_msgs rospy roscpp tf urdf urdfdom_py ros_ethercat_model moveit_ros_planning_interface moveit_ros_manipulation moveit_ros_move_group std_msgs message_runtime
+        CATKIN_DEPENDS sensor_msgs sr_robot_msgs rospy roscpp tf urdf urdfdom_py ros_ethercat_model moveit_ros_planning_interface moveit_ros_manipulation moveit_ros_move_group std_msgs message_runtime sr_utilities_common
         INCLUDE_DIRS include
         LIBRARIES sr_calibration sr_trajectory_command_publisher
 )

--- a/sr_utilities/include/sr_utilities/sr_trajectory_command_publisher.hpp
+++ b/sr_utilities/include/sr_utilities/sr_trajectory_command_publisher.hpp
@@ -27,12 +27,13 @@
 class SrTrajectoryCommandPublisher
 {
 public:
-  SrTrajectoryCommandPublisher();
+  SrTrajectoryCommandPublisher(const std::vector<std::string>& expected_joints = {});
   ~SrTrajectoryCommandPublisher();
-  void publish(trajectory_msgs::JointTrajectory joint_trajectory);
+  void publish(const trajectory_msgs::JointTrajectory& joint_trajectory);
 
 private:
-  void setup_publishers();
+  void setup_publishers(const std::vector<std::string>& expected_joints);
+  std::vector<std::string> xmlrpcvalue_to_vector(const XmlRpc::XmlRpcValue& xmlrpcvalue);
 
   std::map<std::string, std::shared_ptr<std::pair<ros::Publisher,
     trajectory_msgs::JointTrajectory>>> joint_to_publisher_and_msg_;

--- a/sr_utilities/include/sr_utilities/sr_trajectory_command_publisher.hpp
+++ b/sr_utilities/include/sr_utilities/sr_trajectory_command_publisher.hpp
@@ -23,11 +23,12 @@
 #include <string>
 #include <trajectory_msgs/JointTrajectory.h>
 #include <utility>
+#include <vector>
 
 class SrTrajectoryCommandPublisher
 {
 public:
-  SrTrajectoryCommandPublisher(const std::vector<std::string>& expected_joints = {});
+  explicit SrTrajectoryCommandPublisher(const std::vector<std::string>& expected_joints = {});
   ~SrTrajectoryCommandPublisher();
   void publish(const trajectory_msgs::JointTrajectory& joint_trajectory);
 

--- a/sr_utilities/include/sr_utilities/sr_trajectory_command_publisher.hpp
+++ b/sr_utilities/include/sr_utilities/sr_trajectory_command_publisher.hpp
@@ -27,12 +27,15 @@
 class SrTrajectoryCommandPublisher
 {
 public:
+  SrTrajectoryCommandPublisher();
+  ~SrTrajectoryCommandPublisher();
   void publish(trajectory_msgs::JointTrajectory joint_trajectory);
+
 private:
+  void setup_publishers();
+
   std::map<std::string, std::shared_ptr<std::pair<ros::Publisher,
     trajectory_msgs::JointTrajectory>>> joint_to_publisher_and_msg_;
-  std::shared_ptr<std::pair<ros::Publisher, trajectory_msgs::JointTrajectory>>
-    get_publisher_and_msg(std::string joint_name);
 };
 
 #endif  // _SR_TRAJECTORY_COMMAND_PUBLISHER_HPP_

--- a/sr_utilities/include/sr_utilities/sr_trajectory_command_publisher.hpp
+++ b/sr_utilities/include/sr_utilities/sr_trajectory_command_publisher.hpp
@@ -34,6 +34,7 @@ public:
 private:
   void setup_publishers(const std::vector<std::string>& expected_joints);
   std::vector<std::string> xmlrpcvalue_to_vector(const XmlRpc::XmlRpcValue& xmlrpcvalue);
+  void check_for_unsupported_joints(const std::vector<std::string>& expected_joints);
 
   std::map<std::string, std::shared_ptr<std::pair<ros::Publisher,
     trajectory_msgs::JointTrajectory>>> joint_to_publisher_and_msg_;

--- a/sr_utilities/package.xml
+++ b/sr_utilities/package.xml
@@ -29,6 +29,7 @@
     <build_depend>moveit_ros_move_group</build_depend>
     <build_depend>std_msgs</build_depend>
     <build_depend>message_runtime</build_depend>
+    <build_depend>sr_utilities_common</build_depend>
 
     <!-- Dependencies needed after this package is compiled. -->
     <run_depend>sensor_msgs</run_depend>
@@ -45,6 +46,7 @@
     <run_depend>moveit_ros_move_group</run_depend>
     <run_depend>std_msgs</run_depend>
     <run_depend>message_runtime</run_depend>
+    <run_depend>sr_utilities_common</run_depend>
 
     <!-- Dependencies needed only for running tests. -->
     <test_depend>gtest</test_depend>

--- a/sr_utilities/src/sr_trajectory_command_publisher.cpp
+++ b/sr_utilities/src/sr_trajectory_command_publisher.cpp
@@ -21,6 +21,7 @@
 #include <string>
 #include <unordered_set>
 #include <utility>
+#include <vector>
 #include <sr_utilities_common/wait_for_param.h>
 
 SrTrajectoryCommandPublisher::SrTrajectoryCommandPublisher(const std::vector<std::string>& expected_joints)
@@ -94,7 +95,6 @@ void SrTrajectoryCommandPublisher::check_for_unsupported_joints(const std::vecto
     throw std::runtime_error("There is no trajectory controller specified"
                                " in /move_group/controller_list for some of expected joints. Terminating... ");
   }
-
 }
 
 std::vector<std::string> SrTrajectoryCommandPublisher::xmlrpcvalue_to_vector(const XmlRpc::XmlRpcValue& xmlrpcvalue)

--- a/sr_utilities/src/sr_trajectory_command_publisher.cpp
+++ b/sr_utilities/src/sr_trajectory_command_publisher.cpp
@@ -74,6 +74,27 @@ void SrTrajectoryCommandPublisher::setup_publishers(const std::vector<std::strin
       joint_to_publisher_and_msg_.insert(std::make_pair(joints[k], publisher_and_msg));
     }
   }
+
+  check_for_unsupported_joints(expected_joints);
+}
+
+void SrTrajectoryCommandPublisher::check_for_unsupported_joints(const std::vector<std::string>& expected_joints)
+{
+  std::vector<std::string> unsupported_joints;
+  for (const auto& expected_joint : expected_joints)
+  {
+    if (joint_to_publisher_and_msg_.find(expected_joint) == joint_to_publisher_and_msg_.end())
+    {
+      unsupported_joints.push_back(expected_joint);
+      ROS_ERROR_STREAM("No trajectory controller specified for joint: " << expected_joint);
+    }
+  }
+  if (unsupported_joints.size() > 0)
+  {
+    throw std::runtime_error("There is no trajectory controller specified"
+                               " in /move_group/controller_list for some of expected joints. Terminating... ");
+  }
+
 }
 
 std::vector<std::string> SrTrajectoryCommandPublisher::xmlrpcvalue_to_vector(const XmlRpc::XmlRpcValue& xmlrpcvalue)

--- a/sr_utilities/src/sr_trajectory_command_publisher.cpp
+++ b/sr_utilities/src/sr_trajectory_command_publisher.cpp
@@ -20,66 +20,73 @@
 #include <string>
 #include <unordered_set>
 #include <utility>
+#include <sr_utilities_common/wait_for_param.h>
 
-void SrTrajectoryCommandPublisher::publish(trajectory_msgs::JointTrajectory joint_trajectory)
+SrTrajectoryCommandPublisher::SrTrajectoryCommandPublisher()
 {
-  std::unordered_set<std::shared_ptr<std::pair<ros::Publisher,
-    trajectory_msgs::JointTrajectory>>> publishers_and_msgs;
-  for (int i = 0; i < joint_trajectory.joint_names.size(); i++)
-  {
-    std::string joint_name = joint_trajectory.joint_names[i];
-    std::shared_ptr<std::pair<ros::Publisher, trajectory_msgs::JointTrajectory>>
-      publisher_and_msg = get_publisher_and_msg(joint_name);
-    if (publishers_and_msgs.insert(publisher_and_msg).second)
-    {
-      // New element was added to the set, reset cached message to the initial state
-      publisher_and_msg->second.header.stamp = joint_trajectory.header.stamp;
-      publisher_and_msg->second.joint_names.clear();
-      publisher_and_msg->second.points[0].positions.clear();
-      publisher_and_msg->second.points[0].time_from_start = joint_trajectory.points[0].time_from_start;
-    }
-    publisher_and_msg->second.joint_names.push_back(joint_name);
-    publisher_and_msg->second.points[0].positions.push_back(joint_trajectory.points[0].positions[i]);
-  }
-  for (auto& publisher_and_msg : publishers_and_msgs)
-  {
-    publisher_and_msg->first.publish(publisher_and_msg->second);
-  }
+  setup_publishers();
 }
 
-std::shared_ptr<std::pair<ros::Publisher, trajectory_msgs::JointTrajectory>>
-  SrTrajectoryCommandPublisher::get_publisher_and_msg(std::string joint_name)
+SrTrajectoryCommandPublisher::~SrTrajectoryCommandPublisher()
 {
-  auto it = joint_to_publisher_and_msg_.find(joint_name);
-  if (it != joint_to_publisher_and_msg_.end())
-  {
-    return it->second;
-  }
+}
+
+void SrTrajectoryCommandPublisher::setup_publishers()
+{
   ros::NodeHandle nh;
   XmlRpc::XmlRpcValue controller_list;
+  wait_for_param(nh, "/move_group/controller_list");
   ros::param::get("/move_group/controller_list", controller_list);
+
   for (int i = 0; i < controller_list.size(); i++)
   {
     XmlRpc::XmlRpcValue controller = controller_list[i];
     std::string controller_name = controller["name"];
     XmlRpc::XmlRpcValue joints = controller["joints"];
-    for (int j = 0; j < joints.size(); j++)
+
+    auto publisher_and_msg = std::make_shared<std::pair<ros::Publisher, trajectory_msgs::JointTrajectory>>(
+        nh.advertise<trajectory_msgs::JointTrajectory>("/" + controller_name + "/command", 1),
+        trajectory_msgs::JointTrajectory());
+
+    for (int k = 0; k < joints.size(); k++)
     {
-      if (joints[j] == joint_name)
-      {
-        std::shared_ptr<std::pair<ros::Publisher, trajectory_msgs::JointTrajectory>> publisher_and_msg =
-          std::make_shared<std::pair<ros::Publisher, trajectory_msgs::JointTrajectory>>(
-            nh.advertise<trajectory_msgs::JointTrajectory>("/" + controller_name + "/command", 1),
-            trajectory_msgs::JointTrajectory());
-        publisher_and_msg->second.points.resize(1);  // Our trajectory controllers use single array of points
-        for (int k = 0; k < joints.size(); k++)
-        {
-          joint_to_publisher_and_msg_.insert(std::make_pair(joints[k], publisher_and_msg));
-        }
-        return publisher_and_msg;
-      }
+      joint_to_publisher_and_msg_.insert(std::make_pair(joints[k], publisher_and_msg));
     }
   }
-  throw std::runtime_error("There is no trajectory controller specified in /move_group/controller_list for joint " +
-    joint_name);
+}
+
+void SrTrajectoryCommandPublisher::publish(trajectory_msgs::JointTrajectory joint_trajectory)
+{
+  std::unordered_set<std::shared_ptr<std::pair<ros::Publisher,
+    trajectory_msgs::JointTrajectory>>> publishers_and_msgs;
+
+  for (int i = 0; i < joint_trajectory.joint_names.size(); i++)
+  {
+    std::string joint_name = joint_trajectory.joint_names[i];
+    std::shared_ptr<std::pair<ros::Publisher, trajectory_msgs::JointTrajectory>>
+      publisher_and_msg = joint_to_publisher_and_msg_.at(joint_name);
+
+    if (publishers_and_msgs.insert(publisher_and_msg).second)
+    {
+      // New element was added to the set, reset cached message to the initial state
+      publisher_and_msg->second.header.stamp = joint_trajectory.header.stamp;
+      publisher_and_msg->second.joint_names.clear();
+      publisher_and_msg->second.points = joint_trajectory.points;
+      for (int k = 0; k < publisher_and_msg->second.points.size(); k++)
+      {
+        publisher_and_msg->second.points[k].positions.clear();
+      }
+    }
+    publisher_and_msg->second.joint_names.push_back(joint_name);
+
+    for (int k = 0; k < joint_trajectory.points.size(); k++)
+    {
+      publisher_and_msg->second.points[k].positions.push_back(joint_trajectory.points[k].positions[i]);
+    }
+  }
+
+  for (auto& publisher_and_msg : publishers_and_msgs)
+  {
+    publisher_and_msg->first.publish(publisher_and_msg->second);
+  }
 }


### PR DESCRIPTION
## Proposed changes

Current implementation of trajectory publisher has two issues:
1. It doesn't support trajectories with more points than one. This is fine for things like arm servoing, however, if we ever use it for different purposes it might become an issue.
2. **It effectively discards the first trajectory that user wants to send**. Again, this is fine for things like arm servoing when we are continuously sending trajectories, but for use cases when one would like to send single trajectories under specific circumstances it would generate buggy behaviour.

This PR fixes both of those issues, the latter by setting up publishers at start-up instead of on demand. There are two ways to create the main object, either without any arguments - that way the object will initialize with all possible available trajectory publisher objects, or with joints vector passed to the constructor - this way the class will initialize only with publishers that correspond to the passed-in joints, i.e. won't start with unused publishers.

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added automated tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [x] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [ ] Manually tested on hardware (if hardware specific or related).

## Documentation

- [x] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
