### PR TITLE
setup.py: Use setuptools instead of distutils

### DIFF
--- a/sr_hand/setup.py
+++ b/sr_hand/setup.py
@@ -13,7 +13,7 @@
 # with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import absolute_import
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml

--- a/sr_tactile_sensors/setup.py
+++ b/sr_tactile_sensors/setup.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml

--- a/sr_utilities/setup.py
+++ b/sr_utilities/setup.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(


### PR DESCRIPTION
See http://wiki.ros.org/noetic/Migration#Setuptools_instead_of_Distutils
