### PR TITLE
Changing read params function to correct place

### DIFF
--- a/sr_mechanism_controllers/src/srh_joint_effort_controller.cpp
+++ b/sr_mechanism_controllers/src/srh_joint_effort_controller.cpp
@@ -114,6 +114,8 @@ namespace controller
     ROS_DEBUG_STREAM(" In Init: " << getJointName() << " This: " << this
                      << " joint_state: " << joint_state_);
 
+    read_parameters();
+
     after_init();
     return true;
   }
@@ -121,7 +123,6 @@ namespace controller
   void SrhEffortJointController::starting(const ros::Time &time)
   {
     command_ = 0.0;
-    read_parameters();
   }
 
   bool SrhEffortJointController::setGains(sr_robot_msgs::SetEffortControllerGains::Request &req,


### PR DESCRIPTION
## Proposed changes

This issue was found when running arm and hand and I was able to start the motor effort controllers one by one in a loop but not all together using the switch controllers service, the latter would stop the arm controller and also not start the effort controllers. It worked find both ways when it was hand only launched.

**FIX:** The read_parameters() function should not be called in the starting() function. The reason for this is that the starting() function is called inside the realtime thread, and the operations in there have to be realtime friendly (i.e. quite fast). Reading stuff from the parameter server is not realtime friendly and that's why when you are starting many controllers, you are effectively slowing down the realtime thread (that deals with both the update calls for the drivers and the update() calls for the controllers) and that makes the arm driver time out.

[Modification already made in position controllers.](https://github.com/shadow-robot/sr_core/blob/noetic-devel/sr_mechanism_controllers/src/srh_joint_position_controller.cpp#L125)

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [x] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [ ] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [ ] Manually tested on hardware (if hardware specific or related).

## Documentation

- [x] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
