### PR TITLE
Added Timeout to calibrate_hand_finder

### DIFF
--- a/sr_utilities/launch/calibrate_hand_finder.launch
+++ b/sr_utilities/launch/calibrate_hand_finder.launch
@@ -1,7 +1,9 @@
 <launch>
     <arg name="node_shutdown" default="false" />
+    <arg name="node_timeout" default="120" />
 
     <node name="calibrate_hand" pkg="sr_utilities" type="calibrate_hand_finder.py" output="screen">
         <param name="node_shutdown" value="$(arg node_shutdown)" />
+        <param name="node_timeout" value="$(arg node_timeout)" />
     </node>
 </launch>

--- a/sr_utilities/launch/calibrate_hand_finder.launch
+++ b/sr_utilities/launch/calibrate_hand_finder.launch
@@ -1,5 +1,5 @@
 <!--
- Copyright 2022 Shadow Robot Company Ltd.
+ Copyright 2022-2023 Shadow Robot Company Ltd.
  This program is free software: you can redistribute it and/or modify it
  under the terms of the GNU General Public License as published by the Free
  Software Foundation version 2 of the License.

--- a/sr_utilities/scripts/sr_utilities/calibrate_hand_finder.py
+++ b/sr_utilities/scripts/sr_utilities/calibrate_hand_finder.py
@@ -30,8 +30,8 @@ class CalibrateHand(object):
     Once the hands have been successfully reset, this class publishes True on the topic /calibrated
     """
 
-    def __init__(self):
-        rospy.wait_for_service("controller_manager/load_controller", timeout=120.0)
+    def __init__(self, timeout=120.0):
+        rospy.wait_for_service("controller_manager/load_controller", timeout=timeout)
         self.pub_calibrated = rospy.Publisher('calibrated', Bool, queue_size=1, latch=True)
 
     def generate_reset_services_list(self):
@@ -92,16 +92,17 @@ def main():
     rospy.init_node('calibration', anonymous=True)
     # By default should be enabled, except when shutting system down
     ros_node_shutdown = rospy.get_param("~node_shutdown", False)
-
-    calibrate_class = CalibrateHand()
-
+    ros_node_timeout = rospy.get_param("~node_timeout", False)
+    rospy.logerr("1")
+    calibrate_class = CalibrateHand(ros_node_timeout)
+    rospy.logerr("2")
     services = calibrate_class.generate_reset_services_list()
-
+    rospy.logerr("3")
     calibrate_class.pub_calibrated.publish(False)
-
+    rospy.logerr("4")
     if not calibrate_class.calibrate(services):
         sys.exit(3)
-
+    rospy.logerr("5")
     calibrate_class.pub_calibrated.publish(True)
 
     print("Hand calibration complete")

--- a/sr_utilities/scripts/sr_utilities/calibrate_hand_finder.py
+++ b/sr_utilities/scripts/sr_utilities/calibrate_hand_finder.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2014, 2020, 2022 Shadow Robot Company Ltd.
+# Copyright 2014, 2020, 2022-2023 Shadow Robot Company Ltd.
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the Free

--- a/sr_utilities/scripts/sr_utilities/calibrate_hand_finder.py
+++ b/sr_utilities/scripts/sr_utilities/calibrate_hand_finder.py
@@ -93,16 +93,11 @@ def main():
     # By default should be enabled, except when shutting system down
     ros_node_shutdown = rospy.get_param("~node_shutdown", False)
     ros_node_timeout = rospy.get_param("~node_timeout", False)
-    rospy.logerr("1")
     calibrate_class = CalibrateHand(ros_node_timeout)
-    rospy.logerr("2")
     services = calibrate_class.generate_reset_services_list()
-    rospy.logerr("3")
     calibrate_class.pub_calibrated.publish(False)
-    rospy.logerr("4")
     if not calibrate_class.calibrate(services):
         sys.exit(3)
-    rospy.logerr("5")
     calibrate_class.pub_calibrated.publish(True)
 
     print("Hand calibration complete")

--- a/sr_utilities/scripts/sr_utilities/calibrate_hand_finder.py
+++ b/sr_utilities/scripts/sr_utilities/calibrate_hand_finder.py
@@ -94,7 +94,7 @@ def main():
     rospy.init_node('calibration', anonymous=True)
     # By default should be enabled, except when shutting system down
     ros_node_shutdown = rospy.get_param("~node_shutdown", False)
-    ros_node_timeout = rospy.get_param("~node_timeout", False)
+    ros_node_timeout = rospy.get_param("~node_timeout", 120)
     calibrate_class = CalibrateHand(ros_node_timeout)
     services = calibrate_class.generate_reset_services_list()
     calibrate_class.pub_calibrated.publish(False)

--- a/sr_utilities/scripts/sr_utilities/calibrate_hand_finder.py
+++ b/sr_utilities/scripts/sr_utilities/calibrate_hand_finder.py
@@ -23,6 +23,8 @@ from std_msgs.msg import Bool
 from std_srvs.srv import Empty
 
 
+CALIBRATE_TIMEOUT=120.0
+
 class CalibrateHand:
     """
     This class resets all the motor boards of the Shadow Hand E present in the system.
@@ -30,7 +32,7 @@ class CalibrateHand:
     Once the hands have been successfully reset, this class publishes True on the topic /calibrated
     """
 
-    def __init__(self, timeout=120.0):
+    def __init__(self, timeout=CALIBRATE_TIMEOUT):
         rospy.wait_for_service("controller_manager/load_controller", timeout=timeout)
         self.pub_calibrated = rospy.Publisher('calibrated', Bool, queue_size=1, latch=True)
 
@@ -94,7 +96,7 @@ def main():
     rospy.init_node('calibration', anonymous=True)
     # By default should be enabled, except when shutting system down
     ros_node_shutdown = rospy.get_param("~node_shutdown", False)
-    ros_node_timeout = rospy.get_param("~node_timeout", 120)
+    ros_node_timeout = rospy.get_param("~node_timeout", CALIBRATE_TIMEOUT)
     calibrate_class = CalibrateHand(ros_node_timeout)
     services = calibrate_class.generate_reset_services_list()
     calibrate_class.pub_calibrated.publish(False)

--- a/sr_utilities/scripts/sr_utilities/calibrate_hand_finder.py
+++ b/sr_utilities/scripts/sr_utilities/calibrate_hand_finder.py
@@ -23,7 +23,8 @@ from std_msgs.msg import Bool
 from std_srvs.srv import Empty
 
 
-CALIBRATE_TIMEOUT=120.0
+CALIBRATE_TIMEOUT = 120.0
+
 
 class CalibrateHand:
     """


### PR DESCRIPTION
## Proposed changes

Added timeout to calibrate_hand_finder launch file. So that when using the close_everything icon it doesn't wait 120 seconds to find a hand.

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [x] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [ ] Manually tested on hardware (if hardware specific or related).

## Documentation

- [ ] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
