### PR TITLE
[ROS-O] drop deprecated use of boost _1, _2

### DIFF
--- a/sr_hand/include/sr_hand/sr_subscriber.h
+++ b/sr_hand/include/sr_hand/sr_subscriber.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2010 Shadow Robot Company Ltd.
+* Copyright 2010, 2024 Shadow Robot Company Ltd.
 *
 * This program is free software: you can redistribute it and/or modify it
 * under the terms of the GNU General Public License as published by the Free
@@ -101,7 +101,7 @@ private:
    * @param msg the target in radians
    * @param joint_name name of the joint we're sending the command to
    */
-  void cmd_callback(const std_msgs::Float64ConstPtr &msg, std::string &joint_name);
+  void cmd_callback(const std_msgs::Float64ConstPtr &msg, const std::string &joint_name);
 
   /// The vector of subscribers to the different joint topics.
   std::vector<Subscriber> controllers_sub;

--- a/sr_hand/src/sr_subscriber.cpp
+++ b/sr_hand/src/sr_subscriber.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2010 Shadow Robot Company Ltd.
+* Copyright 2010, 2024 Shadow Robot Company Ltd.
 *
 * This program is free software: you can redistribute it and/or modify it
 * under the terms of the GNU General Public License as published by the Free
@@ -81,9 +81,10 @@ namespace shadowrobot
     for (SRArticulatedRobot::JointsMap::iterator joint = sr_articulated_robot->joints_map.begin();
          joint != sr_articulated_robot->joints_map.end(); ++joint)
     {
+      std::string joint_name{ joint->first };
       controllers_sub.push_back(node.subscribe<std_msgs::Float64>(
               "sh_" + boost::to_lower_copy(joint->first + "_position_controller/command"), 2,
-              boost::bind(&SRSubscriber::cmd_callback, this, _1, joint->first)));
+              [this, joint_name](auto msg) { cmd_callback(msg, joint_name); }));
     }
   }
 
@@ -110,7 +111,7 @@ namespace shadowrobot
     }
   }
 
-  void SRSubscriber::cmd_callback(const std_msgs::Float64ConstPtr &msg, std::string &joint_name)
+  void SRSubscriber::cmd_callback(const std_msgs::Float64ConstPtr &msg, const std::string &joint_name)
   {
     // converting to degrees as the old can interface was expecting degrees
     sr_articulated_robot->sendupdate(joint_name, sr_math_utils::to_degrees(msg->data));

--- a/sr_mechanism_controllers/src/joint_spline_trajectory_action_controller.cpp
+++ b/sr_mechanism_controllers/src/joint_spline_trajectory_action_controller.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2011 Shadow Robot Company Ltd.
+* Copyright 2011, 2024 Shadow Robot Company Ltd.
 *
 * This program is free software: you can redistribute it and/or modify it
 * under the terms of the GNU General Public License as published by the Free
@@ -140,8 +140,7 @@ namespace shadowrobot
           nh_tilde("~"), use_sendupdate(false)
   {
     action_server = boost::shared_ptr<JTAS>(new JTAS("/r_arm_controller/joint_trajectory_action",
-                                                     boost::bind(&JointTrajectoryActionController::execute_trajectory,
-                                                                 this, _1),
+                                                     [this](auto msg){ execute_trajectory(msg); },
                                                      false));
     std::vector<std::string> joint_labels;
 

--- a/sr_mechanism_controllers/src/joint_trajectory_action_controller.cpp
+++ b/sr_mechanism_controllers/src/joint_trajectory_action_controller.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2011 Shadow Robot Company Ltd.
+* Copyright 2011, 2024 Shadow Robot Company Ltd.
 *
 * This program is free software: you can redistribute it and/or modify it
 * under the terms of the GNU General Public License as published by the Free
@@ -38,7 +38,7 @@ namespace shadowrobot
   {
     action_server = boost::shared_ptr<JTAS>(
             new JTAS("/r_arm_controller/joint_trajectory_action",
-                     boost::bind(&JointTrajectoryActionController::execute_trajectory, this, _1),
+                     [this](auto msg){ execute_trajectory(msg); },
                      false));
 
     // Create a map of joint names to their command publishers

--- a/sr_tactile_sensors/package.xml
+++ b/sr_tactile_sensors/package.xml
@@ -1,5 +1,5 @@
 <!--
- Copyright 2022 Shadow Robot Company Ltd.
+ Copyright 2022, 2024 Shadow Robot Company Ltd.
  This program is free software: you can redistribute it and/or modify it
  under the terms of the GNU General Public License as published by the Free
  Software Foundation version 2 of the License.


### PR DESCRIPTION
The symbols have always been used through implicit includes from
ros_comm, but ROS-O considers changing these includes right now because
of excessive deprecation warnings building all of ROS.
https://github.com/ros-o/ros_comm/pull/3

Without this noetic-compatible patch, these packages will fail to build with ROS-O, e.g., on Ubuntu 22.04, 24.04 and similar systems, in the near future.

See here for similar changes in the shadow-robot stack:
https://github.com/shadow-robot/sr-ros-interface-ethercat/pull/267
